### PR TITLE
chore: Swagger 설정 및 공통 예외 응답 처리 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,10 +84,6 @@ reviews:
       instructions: |
         1. 비밀 정보 하드코딩 여부
 
-tools:
-  pmd:
-    enabled: true
-
 chat:
   auto_reply: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,11 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,intellij
+
+### Gradle ###
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+### IntelliJ IDEA ###
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/io/dnd/goyo/common/exception/BusinessException.java
+++ b/src/main/java/io/dnd/goyo/common/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package io.dnd.goyo.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        this(errorCode, errorCode.getMessage());
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
+++ b/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package io.dnd.goyo.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 입력입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_002", "서버 오류가 발생했습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_002", "권한이 없습니다"),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/io/dnd/goyo/common/exception/ErrorResponse.java
+++ b/src/main/java/io/dnd/goyo/common/exception/ErrorResponse.java
@@ -1,0 +1,23 @@
+package io.dnd.goyo.common.exception;
+
+import java.util.List;
+
+public record ErrorResponse(
+    String code,
+    String message,
+    List<FieldError> errors
+) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors);
+    }
+
+    public record FieldError(
+        String field,
+        String reason
+    ) {
+    }
+}

--- a/src/main/java/io/dnd/goyo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/dnd/goyo/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package io.dnd.goyo.common.exception;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(new ErrorResponse(errorCode.getCode(), e.getMessage(), null));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidJsonException(HttpMessageNotReadableException e) {
+        return ResponseEntity
+            .status(ErrorCode.INVALID_INPUT.getStatus())
+            .body(ErrorResponse.of(ErrorCode.INVALID_INPUT));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(error -> new ErrorResponse.FieldError(
+                error.getField(),
+                error.getDefaultMessage() != null ? error.getDefaultMessage() : "입력값이 올바르지 않습니다"
+            ))
+            .toList();
+
+        return ResponseEntity
+            .status(ErrorCode.INVALID_INPUT.getStatus())
+            .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+            .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+            .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/io/dnd/goyo/config/SecurityConfig.java
+++ b/src/main/java/io/dnd/goyo/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package io.dnd.goyo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorize -> authorize
+                    .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+                    .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/src/main/java/io/dnd/goyo/config/SwaggerConfig.java
+++ b/src/main/java/io/dnd/goyo/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package io.dnd.goyo.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("JWT 토큰을 입력해주세요 (Bearer 제외)")));
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("고작 API")
+                .description("고작 OpenAPI 문서")
+                .version("v1.0.0")
+                .contact(new Contact()
+                        .name("DND-14 10팀")
+                        .url("https://github.com/dnd-side-project/dnd-14th-10-backend"));
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] Swagger 설정 추가
- [x] 공통 에러 응답 포맷 구현
- [x] 전역 예외 처리 구현        

## 💡 자세한 설명
### Swagger 설정 추가
  - 접속 링크 :  `http://localhost:8080/swagger-ui/index.html#`
<img width="1514" height="696" alt="image" src="https://github.com/user-attachments/assets/028f5564-acee-4136-891d-4c999c619612" />

### 공통 에러 응답 포맷 추가
`ErrorCode`에서 HTTP 상태, 커스텀 코드, 메시지를 관리하도록 하였고 `ErrorResponse`에서 공통 에러 응답 포맷을 정의해놨습니다.                                                                                                 `BusinessException`은 비즈니스 로직 예외를 일관된 응답 형태로 내려줄 수 있도록 구현했습니다.                                                                         
                                                                                                                                                                                                                                                                                                                                                       
### 전역 예외 처리 로직 구현                                                                                                                                                                                                                       
`GlobalExceptionHandler`에서 예외를 공통 포맷으로 변환해서 응답하도록 구현했습니다! 

## ✅ 셀프 체크리스트

- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #5 
