### PR TITLE
feat: 유저 CRUD 기능 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
+++ b/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     INVALID_SIGNUP_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_008", "유효하지 않은 회원가입 토큰입니다"),
 
     // User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다"),
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER_002", "이미 탈퇴한 사용자입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/io/dnd/goyo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/dnd/goyo/common/exception/GlobalExceptionHandler.java
@@ -35,6 +35,27 @@ public class GlobalExceptionHandler {
             .body(ErrorResponse.of(ErrorCode.INVALID_INPUT));
     }
 
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            jakarta.validation.ConstraintViolationException e) {
+        List<ErrorResponse.FieldError> fieldErrors = e.getConstraintViolations()
+            .stream()
+            .map(violation -> new ErrorResponse.FieldError(
+                extractFieldName(violation.getPropertyPath().toString()),
+                violation.getMessage()
+            ))
+            .toList();
+
+        return ResponseEntity
+            .status(ErrorCode.INVALID_INPUT.getStatus())
+            .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors));
+    }
+
+    private String extractFieldName(String propertyPath) {
+        int lastDot = propertyPath.lastIndexOf('.');
+        return lastDot >= 0 ? propertyPath.substring(lastDot + 1) : propertyPath;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
         List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult()

--- a/src/main/java/io/dnd/goyo/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/dto/request/SignupRequest.java
@@ -36,7 +36,7 @@ public record SignupRequest(
         @Schema(description = "위치 정보 동의 여부", example = "true")
         Boolean locationConsent,
 
-        @Schema(description = "거주지 행정구역 코드 (5자리)", example = "11680")
-        Integer regionCode
+        @Schema(description = "거주지 행정구역 코드 (10자리)", example = "1168010100")
+        Long regionCode
 ) {
 }

--- a/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
         Provider provider = tokenInfo.provider();
         String providerId = tokenInfo.providerId();
 
-        if (userRepository.existsByNickname(request.nickname())) {
+        if (userRepository.existsByNicknameAndStatusNot(request.nickname(), UserStatus.DELETED)) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
 

--- a/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
@@ -115,6 +115,9 @@ public class AuthService {
     }
 
     private void validateUserStatus(User user) {
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
         if (user.getStatus() == UserStatus.BLOCKED) {
             throw new BusinessException(ErrorCode.USER_BLOCKED);
         }

--- a/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
+++ b/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
@@ -1,0 +1,121 @@
+package io.dnd.goyo.domain.user.controller;
+
+import io.dnd.goyo.domain.user.dto.request.UpdateBirthRequest;
+import io.dnd.goyo.domain.user.dto.request.UpdateGenderRequest;
+import io.dnd.goyo.domain.user.dto.request.UpdateLocationConsentRequest;
+import io.dnd.goyo.domain.user.dto.request.UpdateNicknameRequest;
+import io.dnd.goyo.domain.user.dto.request.UpdateProfileImageRequest;
+import io.dnd.goyo.domain.user.dto.request.UpdateRegionRequest;
+import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
+import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.service.UserService;
+import io.dnd.goyo.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "현재 로그인한 유저의 프로필 정보를 조회합니다")
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserProfileResponse response = userService.getMyProfile(userDetails.userId());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 유저의 계정을 탈퇴 처리합니다")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.withdraw(userDetails.userId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "닉네임 중복 검사", description = "닉네임이 사용 가능한지 확인합니다")
+    @GetMapping("/nickname/check")
+    public ResponseEntity<NicknameCheckResponse> checkNickname(
+            @RequestParam String nickname
+    ) {
+        NicknameCheckResponse response = userService.checkNickname(nickname);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "닉네임 수정", description = "현재 로그인한 유저의 닉네임을 수정합니다")
+    @PatchMapping("/me/nickname")
+    public ResponseEntity<Void> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateNicknameRequest request
+    ) {
+        userService.updateNickname(userDetails.userId(), request.nickname());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "성별 수정", description = "현재 로그인한 유저의 성별을 수정합니다")
+    @PatchMapping("/me/gender")
+    public ResponseEntity<Void> updateGender(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateGenderRequest request
+    ) {
+        userService.updateGender(userDetails.userId(), request.gender());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "생년월일 수정", description = "현재 로그인한 유저의 생년월일을 수정합니다")
+    @PatchMapping("/me/birth")
+    public ResponseEntity<Void> updateBirth(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateBirthRequest request
+    ) {
+        userService.updateBirth(userDetails.userId(), request.birth());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "거주지 수정", description = "현재 로그인한 유저의 거주지를 수정합니다")
+    @PatchMapping("/me/region")
+    public ResponseEntity<Void> updateRegion(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateRegionRequest request
+    ) {
+        userService.updateRegionCode(userDetails.userId(), request.regionCode());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "위치정보 동의 수정", description = "현재 로그인한 유저의 위치정보 동의 여부를 수정합니다")
+    @PatchMapping("/me/location-consent")
+    public ResponseEntity<Void> updateLocationConsent(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateLocationConsentRequest request
+    ) {
+        userService.updateLocationConsent(userDetails.userId(), request.locationConsent());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 유저의 프로필 이미지를 수정합니다. null 전송 시 이미지가 삭제됩니다")
+    @PatchMapping("/me/profile-image")
+    public ResponseEntity<Void> updateProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdateProfileImageRequest request
+    ) {
+        userService.updateProfileImg(userDetails.userId(), request.profileImg());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
+++ b/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import io.dnd.goyo.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,11 +21,13 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저 API")
+@Validated
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -53,7 +56,7 @@ public class UserController {
     @Operation(summary = "닉네임 중복 검사", description = "닉네임이 사용 가능한지 확인합니다")
     @GetMapping("/nickname/check")
     public ResponseEntity<NicknameCheckResponse> checkNickname(
-            @RequestParam String nickname
+            @RequestParam @NotBlank(message = "닉네임은 필수입니다") String nickname
     ) {
         NicknameCheckResponse response = userService.checkNickname(nickname);
         return ResponseEntity.ok(response);
@@ -66,7 +69,7 @@ public class UserController {
             @Valid @RequestBody UpdateNicknameRequest request
     ) {
         userService.updateNickname(userDetails.userId(), request.nickname());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "성별 수정", description = "현재 로그인한 유저의 성별을 수정합니다")
@@ -76,7 +79,7 @@ public class UserController {
             @Valid @RequestBody UpdateGenderRequest request
     ) {
         userService.updateGender(userDetails.userId(), request.gender());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "생년월일 수정", description = "현재 로그인한 유저의 생년월일을 수정합니다")
@@ -86,7 +89,7 @@ public class UserController {
             @Valid @RequestBody UpdateBirthRequest request
     ) {
         userService.updateBirth(userDetails.userId(), request.birth());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "거주지 수정", description = "현재 로그인한 유저의 거주지를 수정합니다")
@@ -96,7 +99,7 @@ public class UserController {
             @Valid @RequestBody UpdateRegionRequest request
     ) {
         userService.updateRegionCode(userDetails.userId(), request.regionCode());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "위치정보 동의 수정", description = "현재 로그인한 유저의 위치정보 동의 여부를 수정합니다")
@@ -106,7 +109,7 @@ public class UserController {
             @Valid @RequestBody UpdateLocationConsentRequest request
     ) {
         userService.updateLocationConsent(userDetails.userId(), request.locationConsent());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 유저의 프로필 이미지를 수정합니다. null 전송 시 이미지가 삭제됩니다")
@@ -116,6 +119,6 @@ public class UserController {
             @RequestBody UpdateProfileImageRequest request
     ) {
         userService.updateProfileImg(userDetails.userId(), request.profileImg());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateBirthRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateBirthRequest.java
@@ -1,0 +1,13 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Schema(description = "생년월일 수정 요청")
+public record UpdateBirthRequest(
+        @Schema(description = "생년월일", example = "1995-03-15")
+        @NotNull(message = "생년월일은 필수입니다")
+        LocalDate birth
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateGenderRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateGenderRequest.java
@@ -1,0 +1,13 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "성별 수정 요청")
+public record UpdateGenderRequest(
+        @Schema(description = "성별", example = "MALE")
+        @NotNull(message = "성별은 필수입니다")
+        Gender gender
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateLocationConsentRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateLocationConsentRequest.java
@@ -1,0 +1,12 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "위치정보 동의 수정 요청")
+public record UpdateLocationConsentRequest(
+        @Schema(description = "위치정보 동의 여부", example = "true")
+        @NotNull(message = "위치정보 동의 여부는 필수입니다")
+        Boolean locationConsent
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,14 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "닉네임 수정 요청")
+public record UpdateNicknameRequest(
+        @Schema(description = "닉네임", example = "고요한여행자")
+        @NotBlank(message = "닉네임은 필수입니다")
+        @Size(max = 30, message = "닉네임은 30자 이내여야 합니다")
+        String nickname
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateProfileImageRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateProfileImageRequest.java
@@ -1,0 +1,10 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 이미지 수정 요청")
+public record UpdateProfileImageRequest(
+        @Schema(description = "프로필 이미지 URL (null이면 이미지 삭제)", example = "https://example.com/profile.jpg")
+        String profileImg
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateRegionRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateRegionRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "거주지 수정 요청")
 public record UpdateRegionRequest(
-        @Schema(description = "거주지 행정구역 코드 (5자리)", example = "11680")
+        @Schema(description = "거주지 행정구역 코드 (10자리)", example = "1168010100")
         @NotNull(message = "거주지 코드는 필수입니다")
-        Integer regionCode
+        Long regionCode
 ) {
 }

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateRegionRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateRegionRequest.java
@@ -1,0 +1,12 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "거주지 수정 요청")
+public record UpdateRegionRequest(
+        @Schema(description = "거주지 행정구역 코드 (5자리)", example = "11680")
+        @NotNull(message = "거주지 코드는 필수입니다")
+        Integer regionCode
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/response/NicknameCheckResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/response/NicknameCheckResponse.java
@@ -1,0 +1,12 @@
+package io.dnd.goyo.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "닉네임 중복 검사 응답")
+public record NicknameCheckResponse(
+        @Schema(description = "사용 가능 여부", example = "true") boolean available
+) {
+    public static NicknameCheckResponse from(boolean available) {
+        return new NicknameCheckResponse(available);
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
@@ -28,8 +28,8 @@ public record UserProfileResponse(
         @Schema(description = "위치정보 동의 여부", example = "true")
         Boolean locationConsent,
 
-        @Schema(description = "거주지 행정구역 코드", example = "11680")
-        Integer regionCode
+        @Schema(description = "거주지 행정구역 코드", example = "1168010100")
+        Long regionCode
 ) {
     public static UserProfileResponse from(User user) {
         return new UserProfileResponse(

--- a/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,46 @@
+package io.dnd.goyo.domain.user.dto.response;
+
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+@Schema(description = "유저 프로필 응답")
+public record UserProfileResponse(
+        @Schema(description = "유저 ID", example = "1")
+        Long id,
+
+        @Schema(description = "이름", example = "김고작")
+        String name,
+
+        @Schema(description = "닉네임", example = "고작이")
+        String nickname,
+
+        @Schema(description = "생년월일", example = "1995-03-15")
+        LocalDate birth,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImg,
+
+        @Schema(description = "위치정보 동의 여부", example = "true")
+        Boolean locationConsent,
+
+        @Schema(description = "거주지 행정구역 코드", example = "11680")
+        Integer regionCode
+) {
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(
+                user.getId(),
+                user.getName(),
+                user.getNickname(),
+                user.getBirth(),
+                user.getGender(),
+                user.getProfileImg(),
+                user.getLocationConsent(),
+                user.getRegionCode()
+        );
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/user/entity/User.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,7 +71,7 @@ public class User extends BaseEntity {
     private Boolean locationConsent;
 
     @Column(name = "region_code")
-    private Integer regionCode;
+    private Long regionCode;
 
     @Builder
     private User(
@@ -84,7 +85,7 @@ public class User extends BaseEntity {
             String providerId,
             UserRole role,
             Boolean locationConsent,
-            Integer regionCode
+            Long regionCode
     ) {
         validateName(name);
         validateNickname(nickname);
@@ -161,7 +162,7 @@ public class User extends BaseEntity {
         this.birth = birth;
     }
 
-    public void updateRegionCode(Integer regionCode) {
+    public void updateRegionCode(Long regionCode) {
         this.regionCode = regionCode;
     }
 
@@ -177,6 +178,7 @@ public class User extends BaseEntity {
         if (this.status == UserStatus.DELETED) {
             throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
         }
+        this.nickname = "deleted_" + UUID.randomUUID().toString().substring(0, 8);
         this.status = UserStatus.DELETED;
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/user/entity/User.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/User.java
@@ -146,4 +146,37 @@ public class User extends BaseEntity {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "사용자 권한은 필수입니다.");
         }
     }
+
+    public void updateNickname(String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+    }
+
+    public void updateGender(Gender gender) {
+        validateGender(gender);
+        this.gender = gender;
+    }
+
+    public void updateBirth(LocalDate birth) {
+        this.birth = birth;
+    }
+
+    public void updateRegionCode(Integer regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    public void updateLocationConsent(Boolean locationConsent) {
+        this.locationConsent = locationConsent;
+    }
+
+    public void updateProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
+
+    public void withdraw() {
+        if (this.status == UserStatus.DELETED) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_DELETED);
+        }
+        this.status = UserStatus.DELETED;
+    }
 }

--- a/src/main/java/io/dnd/goyo/domain/user/enums/UserStatus.java
+++ b/src/main/java/io/dnd/goyo/domain/user/enums/UserStatus.java
@@ -2,5 +2,6 @@ package io.dnd.goyo.domain.user.enums;
 
 public enum UserStatus {
     ACTIVE,
-    BLOCKED
+    BLOCKED,
+    DELETED
 }

--- a/src/main/java/io/dnd/goyo/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package io.dnd.goyo.domain.user.repository;
 
 import io.dnd.goyo.domain.user.entity.User;
 import io.dnd.goyo.domain.user.enums.Provider;
+import io.dnd.goyo.domain.user.enums.UserStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndStatusNot(String nickname, UserStatus status);
 }

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserReader.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserReader.java
@@ -3,6 +3,7 @@ package io.dnd.goyo.domain.user.service;
 import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.enums.UserStatus;
 import io.dnd.goyo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,13 @@ public class UserReader {
     private final UserRepository userRepository;
 
     public User getUser(Long userId) {
-        return userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        return user;
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
 import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
 import io.dnd.goyo.domain.user.entity.User;
 import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.enums.UserStatus;
 import io.dnd.goyo.domain.user.repository.UserRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -26,16 +27,19 @@ public class UserService {
     }
 
     public NicknameCheckResponse checkNickname(String nickname) {
-        boolean exists = userRepository.existsByNickname(nickname);
+        boolean exists = userRepository.existsByNicknameAndStatusNot(nickname, UserStatus.DELETED);
         return NicknameCheckResponse.from(!exists);
     }
 
     @Transactional
     public void updateNickname(Long userId, String nickname) {
-        if (userRepository.existsByNickname(nickname)) {
+        User user = userReader.getUser(userId);
+        if (user.getNickname().equals(nickname)) {
+            return;
+        }
+        if (userRepository.existsByNicknameAndStatusNot(nickname, UserStatus.DELETED)) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
-        User user = userReader.getUser(userId);
         user.updateNickname(nickname);
     }
 
@@ -52,7 +56,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateRegionCode(Long userId, Integer regionCode) {
+    public void updateRegionCode(Long userId, Long regionCode) {
         User user = userReader.getUser(userId);
         user.updateRegionCode(regionCode);
     }

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
@@ -1,0 +1,77 @@
+package io.dnd.goyo.domain.user.service;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
+import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserReader userReader;
+    private final UserRepository userRepository;
+
+    public UserProfileResponse getMyProfile(Long userId) {
+        User user = userReader.getUser(userId);
+        return UserProfileResponse.from(user);
+    }
+
+    public NicknameCheckResponse checkNickname(String nickname) {
+        boolean exists = userRepository.existsByNickname(nickname);
+        return NicknameCheckResponse.from(!exists);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+        User user = userReader.getUser(userId);
+        user.updateNickname(nickname);
+    }
+
+    @Transactional
+    public void updateGender(Long userId, Gender gender) {
+        User user = userReader.getUser(userId);
+        user.updateGender(gender);
+    }
+
+    @Transactional
+    public void updateBirth(Long userId, LocalDate birth) {
+        User user = userReader.getUser(userId);
+        user.updateBirth(birth);
+    }
+
+    @Transactional
+    public void updateRegionCode(Long userId, Integer regionCode) {
+        User user = userReader.getUser(userId);
+        user.updateRegionCode(regionCode);
+    }
+
+    @Transactional
+    public void updateLocationConsent(Long userId, Boolean locationConsent) {
+        User user = userReader.getUser(userId);
+        user.updateLocationConsent(locationConsent);
+    }
+
+    @Transactional
+    public void updateProfileImg(Long userId, String profileImg) {
+        User user = userReader.getUser(userId);
+        user.updateProfileImg(profileImg);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userReader.getUser(userId);
+        user.withdraw();
+    }
+}

--- a/src/main/resources/static/test.html
+++ b/src/main/resources/static/test.html
@@ -53,7 +53,7 @@
 
         <div class="form-group">
             <label>API Base URL</label>
-            <input type="text" id="apiBaseUrl" value="http://localhost:8080">
+            <input type="text" id="apiBaseUrl" value="">
         </div>
 
         <div class="form-group">
@@ -173,7 +173,7 @@
             if (savedClientId) document.getElementById('kakaoClientId').value = savedClientId;
 
             const savedApiUrl = localStorage.getItem('apiBaseUrl');
-            if (savedApiUrl) document.getElementById('apiBaseUrl').value = savedApiUrl;
+            document.getElementById('apiBaseUrl').value = savedApiUrl || window.location.origin;
 
             // Check for auth code in URL
             checkAuthCode();

--- a/src/test/java/io/dnd/goyo/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/auth/service/AuthServiceTest.java
@@ -156,7 +156,7 @@ class AuthServiceTest {
             SignupTokenInfo tokenInfo = new SignupTokenInfo(Provider.KAKAO, "kakao_123");
 
             given(jwtTokenProvider.parseSignupToken("signup_token")).willReturn(tokenInfo);
-            given(userRepository.existsByNickname("고요한여행자")).willReturn(false);
+            given(userRepository.existsByNicknameAndStatusNot("고요한여행자", UserStatus.DELETED)).willReturn(false);
             given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("access_token");
             given(jwtTokenProvider.createRefreshToken(any())).willReturn("refresh_token");
@@ -177,12 +177,12 @@ class AuthServiceTest {
             AuthService authService = createAuthService();
             SignupRequest request = new SignupRequest(
                     "signup_token", "김고요", "고요한여행자", Gender.FEMALE,
-                    LocalDate.of(1995, 3, 15), null, true, 11680
+                    LocalDate.of(1995, 3, 15), null, true, 1168010100L
             );
             SignupTokenInfo tokenInfo = new SignupTokenInfo(Provider.KAKAO, "kakao_123");
 
             given(jwtTokenProvider.parseSignupToken("signup_token")).willReturn(tokenInfo);
-            given(userRepository.existsByNickname("고요한여행자")).willReturn(false);
+            given(userRepository.existsByNicknameAndStatusNot("고요한여행자", UserStatus.DELETED)).willReturn(false);
             given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("access_token");
             given(jwtTokenProvider.createRefreshToken(any())).willReturn("refresh_token");
@@ -207,7 +207,7 @@ class AuthServiceTest {
             SignupTokenInfo tokenInfo = new SignupTokenInfo(Provider.KAKAO, "kakao_123");
 
             given(jwtTokenProvider.parseSignupToken("signup_token")).willReturn(tokenInfo);
-            given(userRepository.existsByNickname("중복닉네임")).willReturn(true);
+            given(userRepository.existsByNicknameAndStatusNot("중복닉네임", UserStatus.DELETED)).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> authService.signup(request))

--- a/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
@@ -63,7 +63,7 @@ class UserControllerTest {
             // given
             UserProfileResponse response = new UserProfileResponse(
                     1L, "김고작", "고작이", LocalDate.of(1995, 3, 15),
-                    Gender.MALE, null, true, 11680
+                    Gender.MALE, null, true, 1168010100L
             );
             given(userService.getMyProfile(1L)).willReturn(response);
 
@@ -97,6 +97,16 @@ class UserControllerTest {
     class CheckNickname {
 
         @Test
+        void 닉네임_빈값이면_400_반환() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/users/nickname/check")
+                            .param("nickname", "")
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0].field").value("nickname"));
+        }
+
+        @Test
         void 닉네임_중복_검사_성공() throws Exception {
             // given
             given(userService.checkNickname("새닉네임"))
@@ -116,7 +126,7 @@ class UserControllerTest {
     class UpdateNickname {
 
         @Test
-        void 닉네임_수정_성공_시_200_반환() throws Exception {
+        void 닉네임_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
                     Map.of("nickname", "새닉네임"));
@@ -126,7 +136,7 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             verify(userService).updateNickname(eq(1L), eq("새닉네임"));
         }
@@ -152,7 +162,7 @@ class UserControllerTest {
     class UpdateGender {
 
         @Test
-        void 성별_수정_성공_시_200_반환() throws Exception {
+        void 성별_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
                     Map.of("gender", "FEMALE"));
@@ -162,7 +172,7 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             verify(userService).updateGender(eq(1L), eq(Gender.FEMALE));
         }
@@ -173,7 +183,7 @@ class UserControllerTest {
     class UpdateBirth {
 
         @Test
-        void 생년월일_수정_성공_시_200_반환() throws Exception {
+        void 생년월일_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
                     Map.of("birth", "1995-03-15"));
@@ -183,7 +193,7 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             verify(userService).updateBirth(eq(1L), eq(LocalDate.of(1995, 3, 15)));
         }
@@ -194,19 +204,19 @@ class UserControllerTest {
     class UpdateRegion {
 
         @Test
-        void 거주지_수정_성공_시_200_반환() throws Exception {
+        void 거주지_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
-                    Map.of("regionCode", 11110));
+                    Map.of("regionCode", 1111010100L));
 
             // when & then
             mockMvc.perform(patch("/api/users/me/region")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
-            verify(userService).updateRegionCode(eq(1L), eq(11110));
+            verify(userService).updateRegionCode(eq(1L), eq(1111010100L));
         }
     }
 
@@ -215,7 +225,7 @@ class UserControllerTest {
     class UpdateLocationConsent {
 
         @Test
-        void 위치정보_동의_수정_성공_시_200_반환() throws Exception {
+        void 위치정보_동의_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
                     Map.of("locationConsent", false));
@@ -225,7 +235,7 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             verify(userService).updateLocationConsent(eq(1L), eq(false));
         }
@@ -236,7 +246,7 @@ class UserControllerTest {
     class UpdateProfileImage {
 
         @Test
-        void 프로필_이미지_수정_성공_시_200_반환() throws Exception {
+        void 프로필_이미지_수정_성공_시_204_반환() throws Exception {
             // given
             String request = objectMapper.writeValueAsString(
                     Map.of("profileImg", "https://example.com/new.jpg"));
@@ -246,7 +256,7 @@ class UserControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request)
                             .with(csrf()))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isNoContent());
 
             verify(userService).updateProfileImg(eq(1L), eq("https://example.com/new.jpg"));
         }

--- a/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,254 @@
+package io.dnd.goyo.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
+import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.service.UserService;
+import io.dnd.goyo.security.CustomUserDetails;
+import io.dnd.goyo.security.jwt.JwtTokenProvider;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        CustomUserDetails userDetails = CustomUserDetails.of(1L, "USER");
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Nested
+    @DisplayName("GET /api/users/me")
+    class GetMyProfile {
+
+        @Test
+        void 프로필_조회_성공_시_200_반환() throws Exception {
+            // given
+            UserProfileResponse response = new UserProfileResponse(
+                    1L, "김고작", "고작이", LocalDate.of(1995, 3, 15),
+                    Gender.MALE, null, true, 11680
+            );
+            given(userService.getMyProfile(1L)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/users/me")
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1))
+                    .andExpect(jsonPath("$.name").value("김고작"))
+                    .andExpect(jsonPath("$.nickname").value("고작이"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/users/me")
+    class Withdraw {
+
+        @Test
+        void 회원_탈퇴_성공_시_204_반환() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/users/me")
+                            .with(csrf()))
+                    .andExpect(status().isNoContent());
+
+            verify(userService).withdraw(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/users/nickname/check")
+    class CheckNickname {
+
+        @Test
+        void 닉네임_중복_검사_성공() throws Exception {
+            // given
+            given(userService.checkNickname("새닉네임"))
+                    .willReturn(NicknameCheckResponse.from(true));
+
+            // when & then
+            mockMvc.perform(get("/api/users/nickname/check")
+                            .param("nickname", "새닉네임")
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.available").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/nickname")
+    class UpdateNickname {
+
+        @Test
+        void 닉네임_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("nickname", "새닉네임"));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/nickname")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateNickname(eq(1L), eq("새닉네임"));
+        }
+
+        @Test
+        void 닉네임_누락_시_400_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("nickname", ""));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/nickname")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.errors[0].field").value("nickname"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/gender")
+    class UpdateGender {
+
+        @Test
+        void 성별_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("gender", "FEMALE"));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/gender")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateGender(eq(1L), eq(Gender.FEMALE));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/birth")
+    class UpdateBirth {
+
+        @Test
+        void 생년월일_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("birth", "1995-03-15"));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/birth")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateBirth(eq(1L), eq(LocalDate.of(1995, 3, 15)));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/region")
+    class UpdateRegion {
+
+        @Test
+        void 거주지_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("regionCode", 11110));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/region")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateRegionCode(eq(1L), eq(11110));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/location-consent")
+    class UpdateLocationConsent {
+
+        @Test
+        void 위치정보_동의_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("locationConsent", false));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/location-consent")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateLocationConsent(eq(1L), eq(false));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/users/me/profile-image")
+    class UpdateProfileImage {
+
+        @Test
+        void 프로필_이미지_수정_성공_시_200_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("profileImg", "https://example.com/new.jpg"));
+
+            // when & then
+            mockMvc.perform(patch("/api/users/me/profile-image")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+
+            verify(userService).updateProfileImg(eq(1L), eq("https://example.com/new.jpg"));
+        }
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
@@ -146,12 +146,12 @@ class UserTest {
             // given & when
             User user = createValidUserBuilder()
                     .locationConsent(true)
-                    .regionCode(11680)
+                    .regionCode(1168010100L)
                     .build();
 
             // then
             assertThat(user.getLocationConsent()).isTrue();
-            assertThat(user.getRegionCode()).isEqualTo(11680);
+            assertThat(user.getRegionCode()).isEqualTo(1168010100L);
         }
 
         @Test
@@ -251,6 +251,7 @@ class UserTest {
 
             // then
             assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+            assertThat(user.getNickname()).startsWith("deleted_");
         }
 
         @Test
@@ -289,10 +290,10 @@ class UserTest {
             User user = createValidUserBuilder().build();
 
             // when
-            user.updateRegionCode(11110);
+            user.updateRegionCode(1111010100L);
 
             // then
-            assertThat(user.getRegionCode()).isEqualTo(11110);
+            assertThat(user.getRegionCode()).isEqualTo(1111010100L);
         }
 
         @Test

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
@@ -167,4 +167,170 @@ class UserTest {
             assertThat(user.getRegionCode()).isNull();
         }
     }
+
+    @Nested
+    @DisplayName("닉네임 수정 시")
+    class UpdateNickname {
+
+        @Test
+        void 정상적인_닉네임으로_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.updateNickname("새닉네임");
+
+            // then
+            assertThat(user.getNickname()).isEqualTo("새닉네임");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void 비어있는_닉네임으로_수정_시_예외_발생(String nickname) {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname(nickname))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("닉네임은 필수입니다");
+        }
+
+        @Test
+        void 닉네임이_30자를_초과하면_예외_발생() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when & then
+            assertThatThrownBy(() -> user.updateNickname("a".repeat(31)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("닉네임은 30자 이내여야 합니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("성별 수정 시")
+    class UpdateGender {
+
+        @Test
+        void 정상적인_성별로_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.updateGender(Gender.FEMALE);
+
+            // then
+            assertThat(user.getGender()).isEqualTo(Gender.FEMALE);
+        }
+
+        @Test
+        void null_성별로_수정_시_예외_발생() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when & then
+            assertThatThrownBy(() -> user.updateGender(null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("성별은 필수입니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 시")
+    class Withdraw {
+
+        @Test
+        void 정상_탈퇴_시_상태가_DELETED() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.withdraw();
+
+            // then
+            assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+        }
+
+        @Test
+        void 이미_탈퇴한_사용자가_다시_탈퇴_시_예외_발생() {
+            // given
+            User user = createValidUserBuilder().build();
+            user.withdraw();
+
+            // when & then
+            assertThatThrownBy(user::withdraw)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("이미 탈퇴한 사용자입니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 수정 시")
+    class UpdateProfile {
+
+        @Test
+        void 생년월일_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+            java.time.LocalDate birth = java.time.LocalDate.of(1995, 3, 15);
+
+            // when
+            user.updateBirth(birth);
+
+            // then
+            assertThat(user.getBirth()).isEqualTo(birth);
+        }
+
+        @Test
+        void 거주지_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.updateRegionCode(11110);
+
+            // then
+            assertThat(user.getRegionCode()).isEqualTo(11110);
+        }
+
+        @Test
+        void 위치정보_동의_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.updateLocationConsent(true);
+
+            // then
+            assertThat(user.getLocationConsent()).isTrue();
+        }
+
+        @Test
+        void 프로필_이미지_수정_가능() {
+            // given
+            User user = createValidUserBuilder().build();
+
+            // when
+            user.updateProfileImg("https://example.com/profile.jpg");
+
+            // then
+            assertThat(user.getProfileImg()).isEqualTo("https://example.com/profile.jpg");
+        }
+
+        @Test
+        void 프로필_이미지_null로_삭제_가능() {
+            // given
+            User user = createValidUserBuilder()
+                    .profileImg("https://example.com/profile.jpg")
+                    .build();
+
+            // when
+            user.updateProfileImg(null);
+
+            // then
+            assertThat(user.getProfileImg()).isNull();
+        }
+    }
 }

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -1,0 +1,271 @@
+package io.dnd.goyo.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
+import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.enums.Provider;
+import io.dnd.goyo.domain.user.enums.UserRole;
+import io.dnd.goyo.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private static User createValidUser() {
+        return User.builder()
+                .name("김고작")
+                .nickname("고작이")
+                .gender(Gender.MALE)
+                .provider(Provider.KAKAO)
+                .role(UserRole.USER)
+                .locationConsent(true)
+                .regionCode(11680)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("프로필 조회")
+    class GetMyProfile {
+
+        @Test
+        void 프로필_조회_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            UserProfileResponse response = userService.getMyProfile(userId);
+
+            // then
+            assertThat(response.name()).isEqualTo("김고작");
+            assertThat(response.nickname()).isEqualTo("고작이");
+            assertThat(response.gender()).isEqualTo(Gender.MALE);
+        }
+
+        @Test
+        void 존재하지_않는_사용자_조회_시_예외_발생() {
+            // given
+            Long userId = 999L;
+            given(userReader.getUser(userId))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> userService.getMyProfile(userId))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 중복 검사")
+    class CheckNickname {
+
+        @Test
+        void 사용_가능한_닉네임이면_available_true() {
+            // given
+            given(userRepository.existsByNickname("새닉네임")).willReturn(false);
+
+            // when
+            NicknameCheckResponse response = userService.checkNickname("새닉네임");
+
+            // then
+            assertThat(response.available()).isTrue();
+        }
+
+        @Test
+        void 중복된_닉네임이면_available_false() {
+            // given
+            given(userRepository.existsByNickname("고작이")).willReturn(true);
+
+            // when
+            NicknameCheckResponse response = userService.checkNickname("고작이");
+
+            // then
+            assertThat(response.available()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 수정")
+    class UpdateNickname {
+
+        @Test
+        void 닉네임_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userRepository.existsByNickname("새닉네임")).willReturn(false);
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateNickname(userId, "새닉네임");
+
+            // then
+            assertThat(user.getNickname()).isEqualTo("새닉네임");
+        }
+
+        @Test
+        void 중복_닉네임으로_수정_시_예외_발생() {
+            // given
+            Long userId = 1L;
+            given(userRepository.existsByNickname("중복닉네임")).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateNickname(userId, "중복닉네임"))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("성별 수정")
+    class UpdateGender {
+
+        @Test
+        void 성별_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateGender(userId, Gender.FEMALE);
+
+            // then
+            assertThat(user.getGender()).isEqualTo(Gender.FEMALE);
+        }
+    }
+
+    @Nested
+    @DisplayName("생년월일 수정")
+    class UpdateBirth {
+
+        @Test
+        void 생년월일_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            LocalDate birth = LocalDate.of(1995, 3, 15);
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateBirth(userId, birth);
+
+            // then
+            assertThat(user.getBirth()).isEqualTo(birth);
+        }
+    }
+
+    @Nested
+    @DisplayName("거주지 수정")
+    class UpdateRegionCode {
+
+        @Test
+        void 거주지_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateRegionCode(userId, 11110);
+
+            // then
+            assertThat(user.getRegionCode()).isEqualTo(11110);
+        }
+    }
+
+    @Nested
+    @DisplayName("위치정보 동의 수정")
+    class UpdateLocationConsent {
+
+        @Test
+        void 위치정보_동의_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateLocationConsent(userId, false);
+
+            // then
+            assertThat(user.getLocationConsent()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 이미지 수정")
+    class UpdateProfileImg {
+
+        @Test
+        void 프로필_이미지_수정_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateProfileImg(userId, "https://example.com/new-profile.jpg");
+
+            // then
+            assertThat(user.getProfileImg()).isEqualTo("https://example.com/new-profile.jpg");
+        }
+
+        @Test
+        void 프로필_이미지_삭제_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateProfileImg(userId, null);
+
+            // then
+            assertThat(user.getProfileImg()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class Withdraw {
+
+        @Test
+        void 회원_탈퇴_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.withdraw(userId);
+
+            // then
+            verify(userReader).getUser(userId);
+        }
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -77,7 +77,8 @@ class UserServiceTest {
 
             // when & then
             assertThatThrownBy(() -> userService.getMyProfile(userId))
-                    .isInstanceOf(BusinessException.class);
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
         }
     }
 
@@ -139,7 +140,8 @@ class UserServiceTest {
 
             // when & then
             assertThatThrownBy(() -> userService.updateNickname(userId, "중복닉네임"))
-                    .isInstanceOf(BusinessException.class);
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATE_NICKNAME);
         }
 
         @Test

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import io.dnd.goyo.domain.user.entity.User;
 import io.dnd.goyo.domain.user.enums.Gender;
 import io.dnd.goyo.domain.user.enums.Provider;
 import io.dnd.goyo.domain.user.enums.UserRole;
+import io.dnd.goyo.domain.user.enums.UserStatus;
 import io.dnd.goyo.domain.user.repository.UserRepository;
 import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +44,7 @@ class UserServiceTest {
                 .provider(Provider.KAKAO)
                 .role(UserRole.USER)
                 .locationConsent(true)
-                .regionCode(11680)
+                .regionCode(1168010100L)
                 .build();
     }
 
@@ -87,7 +88,7 @@ class UserServiceTest {
         @Test
         void 사용_가능한_닉네임이면_available_true() {
             // given
-            given(userRepository.existsByNickname("새닉네임")).willReturn(false);
+            given(userRepository.existsByNicknameAndStatusNot("새닉네임", UserStatus.DELETED)).willReturn(false);
 
             // when
             NicknameCheckResponse response = userService.checkNickname("새닉네임");
@@ -99,7 +100,7 @@ class UserServiceTest {
         @Test
         void 중복된_닉네임이면_available_false() {
             // given
-            given(userRepository.existsByNickname("고작이")).willReturn(true);
+            given(userRepository.existsByNicknameAndStatusNot("고작이", UserStatus.DELETED)).willReturn(true);
 
             // when
             NicknameCheckResponse response = userService.checkNickname("고작이");
@@ -118,8 +119,8 @@ class UserServiceTest {
             // given
             Long userId = 1L;
             User user = createValidUser();
-            given(userRepository.existsByNickname("새닉네임")).willReturn(false);
             given(userReader.getUser(userId)).willReturn(user);
+            given(userRepository.existsByNicknameAndStatusNot("새닉네임", UserStatus.DELETED)).willReturn(false);
 
             // when
             userService.updateNickname(userId, "새닉네임");
@@ -132,11 +133,27 @@ class UserServiceTest {
         void 중복_닉네임으로_수정_시_예외_발생() {
             // given
             Long userId = 1L;
-            given(userRepository.existsByNickname("중복닉네임")).willReturn(true);
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+            given(userRepository.existsByNicknameAndStatusNot("중복닉네임", UserStatus.DELETED)).willReturn(true);
 
             // when & then
             assertThatThrownBy(() -> userService.updateNickname(userId, "중복닉네임"))
                     .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        void 현재_닉네임과_동일하면_변경없이_정상_반환() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.updateNickname(userId, "고작이");
+
+            // then
+            assertThat(user.getNickname()).isEqualTo("고작이");
         }
     }
 
@@ -191,10 +208,10 @@ class UserServiceTest {
             given(userReader.getUser(userId)).willReturn(user);
 
             // when
-            userService.updateRegionCode(userId, 11110);
+            userService.updateRegionCode(userId, 1111010100L);
 
             // then
-            assertThat(user.getRegionCode()).isEqualTo(11110);
+            assertThat(user.getRegionCode()).isEqualTo(1111010100L);
         }
     }
 
@@ -265,7 +282,8 @@ class UserServiceTest {
             userService.withdraw(userId);
 
             // then
-            verify(userReader).getUser(userId);
+            assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+            assertThat(user.getNickname()).startsWith("deleted_");
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 회원 탈퇴 기능
- [x] 회원 닉네임 중복 검사 기능
- [x] 회원 거주지 수정 기능
- [x] 회원 생년월일 수정 기능
- [x] 회원 성별 수정 기능
- [x] 회원 닉네임 수정 기능
- [x] 회원 위치정보 동의 기능
- [x] 회원 프로필사진 수정 기능

## 💡 자세한 설명
유저 CRUD 등 잡다한 기능들을 구현하였습니다.

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #23 
