### PR TITLE
chore: cors 세팅 및 동적 oauth redirect 도입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,5 @@ JWT_SECRET=your-secret-key-at-least-32-characters-long
 # Kakao OAuth
 KAKAO_CLIENT_ID=your-kakao-rest-api-key
 KAKAO_CLIENT_SECRET=your-kakao-client-secret
-KAKAO_REDIRECT_URI=http://localhost:8080/test.html
 
 # 해당 .env 파일 확인하고 환경변수 구성하기

--- a/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
+++ b/src/main/java/io/dnd/goyo/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     USER_BLOCKED(HttpStatus.FORBIDDEN, "AUTH_006", "차단된 사용자입니다"),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "AUTH_007", "이미 사용중인 닉네임입니다"),
     INVALID_SIGNUP_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_008", "유효하지 않은 회원가입 토큰입니다"),
+    INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST, "AUTH_009", "허용되지 않은 리다이렉트 URI입니다"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "사용자를 찾을 수 없습니다"),

--- a/src/main/java/io/dnd/goyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/controller/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
             @Valid @RequestBody OAuthLoginRequest request
     ) {
         Provider oauthProvider = Provider.from(provider);
-        OAuthLoginResponse response = authService.oauthLogin(oauthProvider, request.code());
+        OAuthLoginResponse response = authService.oauthLogin(oauthProvider, request.code(), request.redirectUri());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/io/dnd/goyo/domain/auth/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/dto/request/OAuthLoginRequest.java
@@ -7,6 +7,10 @@ import jakarta.validation.constraints.NotBlank;
 public record OAuthLoginRequest(
         @Schema(description = "OAuth 인가 코드", example = "authorization_code_here")
         @NotBlank(message = "인가 코드는 필수입니다")
-        String code
+        String code,
+
+        @Schema(description = "리다이렉트 URI", example = "http://localhost:5173/oauth/kakao/callback")
+        @NotBlank(message = "리다이렉트 URI는 필수입니다")
+        String redirectUri
 ) {
 }

--- a/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/AuthService.java
@@ -43,9 +43,9 @@ public class AuthService {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public OAuthLoginResponse oauthLogin(Provider provider, String code) {
+    public OAuthLoginResponse oauthLogin(Provider provider, String code, String redirectUri) {
         OAuthProvider oauthProvider = getOAuthProvider(provider);
-        OAuthUserInfo userInfo = oauthProvider.getUserInfo(code);
+        OAuthUserInfo userInfo = oauthProvider.getUserInfo(code, redirectUri);
 
         Optional<User> existingUser = userRepository.findByProviderAndProviderId(
                 userInfo.provider(), userInfo.providerId());

--- a/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProperties.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProperties.java
@@ -7,7 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record KakaoOAuthProperties(
         String clientId,
         String clientSecret,
-        String redirectUri,
         List<String> allowedRedirectUris,
         String tokenUrl,
         String userInfoUrl

--- a/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProperties.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProperties.java
@@ -1,5 +1,6 @@
 package io.dnd.goyo.domain.auth.service.oauth;
 
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "oauth.kakao")
@@ -7,6 +8,7 @@ public record KakaoOAuthProperties(
         String clientId,
         String clientSecret,
         String redirectUri,
+        List<String> allowedRedirectUris,
         String tokenUrl,
         String userInfoUrl
 ) {

--- a/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProvider.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/oauth/KakaoOAuthProvider.java
@@ -30,8 +30,9 @@ public class KakaoOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public OAuthUserInfo getUserInfo(String code) {
-        String accessToken = getAccessToken(code);
+    public OAuthUserInfo getUserInfo(String code, String redirectUri) {
+        validateRedirectUri(redirectUri);
+        String accessToken = getAccessToken(code, redirectUri);
         KakaoUserInfoResponse userInfo = fetchUserInfo(accessToken);
 
         return new OAuthUserInfo(
@@ -42,12 +43,19 @@ public class KakaoOAuthProvider implements OAuthProvider {
         );
     }
 
-    private String getAccessToken(String code) {
+    private void validateRedirectUri(String redirectUri) {
+        if (properties.allowedRedirectUris() == null
+                || !properties.allowedRedirectUris().contains(redirectUri)) {
+            throw new BusinessException(ErrorCode.INVALID_REDIRECT_URI);
+        }
+    }
+
+    private String getAccessToken(String code, String redirectUri) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", properties.clientId());
         body.add("client_secret", properties.clientSecret());
-        body.add("redirect_uri", properties.redirectUri());
+        body.add("redirect_uri", redirectUri);
         body.add("code", code);
 
         KakaoTokenResponse response = restClient.post()

--- a/src/main/java/io/dnd/goyo/domain/auth/service/oauth/OAuthProvider.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/service/oauth/OAuthProvider.java
@@ -6,5 +6,5 @@ public interface OAuthProvider {
 
     Provider getProvider();
 
-    OAuthUserInfo getUserInfo(String code);
+    OAuthUserInfo getUserInfo(String code, String redirectUri);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -62,5 +62,8 @@ oauth:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
+    allowed-redirect-uris:
+      - http://localhost:5173/oauth/kakao/callback
+      - https://gojak.co.kr/oauth/kakao/callback
     token-url: https://kauth.kakao.com/oauth/token
     user-info-url: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,7 +61,6 @@ oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
     allowed-redirect-uris:
       - http://localhost:5173/oauth/kakao/callback
       - https://gojak.co.kr/oauth/kakao/callback

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -61,7 +61,6 @@ oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
     allowed-redirect-uris:
       - http://localhost:5173/oauth/kakao/callback
       - http://localhost:8080/test.html

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -62,5 +62,8 @@ oauth:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
+    allowed-redirect-uris:
+      - http://localhost:5173/oauth/kakao/callback
+      - http://localhost:8080/test.html
     token-url: https://kauth.kakao.com/oauth/token
     user-info-url: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/static/test.html
+++ b/src/main/resources/static/test.html
@@ -266,7 +266,8 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        code: authCode
+                        code: authCode,
+                        redirectUri: getRedirectUri()
                     })
                 });
 

--- a/src/test/java/io/dnd/goyo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/auth/controller/AuthControllerTest.java
@@ -58,8 +58,8 @@ class AuthControllerTest {
                     "access_token", "refresh_token", 1800000L,
                     new UserInfoResponse(1L, "고요한여행자", null)
             );
-            given(authService.oauthLogin(eq(Provider.KAKAO), any(String.class))).willReturn(response);
-            String request = objectMapper.writeValueAsString(Map.of("code", "auth_code"));
+            given(authService.oauthLogin(eq(Provider.KAKAO), any(String.class), any(String.class))).willReturn(response);
+            String request = objectMapper.writeValueAsString(Map.of("code", "auth_code", "redirectUri", "http://localhost:8080/test.html"));
 
             // when & then
             mockMvc.perform(post("/api/auth/oauth/kakao")
@@ -78,8 +78,8 @@ class AuthControllerTest {
             // given
             OAuthUserInfo userInfo = new OAuthUserInfo(Provider.KAKAO, "kakao_new", "새유저", "profile.jpg");
             OAuthLoginResponse response = OAuthLoginResponse.forNewUser("signup_token", userInfo);
-            given(authService.oauthLogin(eq(Provider.KAKAO), any(String.class))).willReturn(response);
-            String request = objectMapper.writeValueAsString(Map.of("code", "auth_code"));
+            given(authService.oauthLogin(eq(Provider.KAKAO), any(String.class), any(String.class))).willReturn(response);
+            String request = objectMapper.writeValueAsString(Map.of("code", "auth_code", "redirectUri", "http://localhost:8080/test.html"));
 
             // when & then
             mockMvc.perform(post("/api/auth/oauth/kakao")
@@ -95,7 +95,7 @@ class AuthControllerTest {
         @WithMockUser
         void 인가코드_누락_시_400_반환() throws Exception {
             // given
-            String request = objectMapper.writeValueAsString(Map.of());
+            String request = objectMapper.writeValueAsString(Map.of("redirectUri", "http://localhost:8080/test.html"));
 
             // when & then
             mockMvc.perform(post("/api/auth/oauth/kakao")

--- a/src/test/java/io/dnd/goyo/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/auth/service/AuthServiceTest.java
@@ -73,7 +73,7 @@ class AuthServiceTest {
             User user = createActiveUser();
             OAuthUserInfo userInfo = new OAuthUserInfo(Provider.KAKAO, "kakao_123", "김고요", null);
 
-            given(kakaoOAuthProvider.getUserInfo("auth_code")).willReturn(userInfo);
+            given(kakaoOAuthProvider.getUserInfo("auth_code", "http://localhost:8080/test.html")).willReturn(userInfo);
             given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "kakao_123"))
                     .willReturn(Optional.of(user));
             given(jwtTokenProvider.createAccessToken(any(), any())).willReturn("access_token");
@@ -81,7 +81,7 @@ class AuthServiceTest {
             given(jwtTokenProvider.getAccessTokenExpiration()).willReturn(1800000L);
 
             // when
-            OAuthLoginResponse response = authService.oauthLogin(Provider.KAKAO, "auth_code");
+            OAuthLoginResponse response = authService.oauthLogin(Provider.KAKAO, "auth_code", "http://localhost:8080/test.html");
 
             // then
             assertThat(response.isNewUser()).isFalse();
@@ -96,14 +96,14 @@ class AuthServiceTest {
             AuthService authService = createAuthService();
             OAuthUserInfo userInfo = new OAuthUserInfo(Provider.KAKAO, "kakao_new", "새유저", "profile.jpg");
 
-            given(kakaoOAuthProvider.getUserInfo("auth_code")).willReturn(userInfo);
+            given(kakaoOAuthProvider.getUserInfo("auth_code", "http://localhost:8080/test.html")).willReturn(userInfo);
             given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "kakao_new"))
                     .willReturn(Optional.empty());
             given(jwtTokenProvider.createSignupToken(Provider.KAKAO, "kakao_new"))
                     .willReturn("signup_token");
 
             // when
-            OAuthLoginResponse response = authService.oauthLogin(Provider.KAKAO, "auth_code");
+            OAuthLoginResponse response = authService.oauthLogin(Provider.KAKAO, "auth_code", "http://localhost:8080/test.html");
 
             // then
             assertThat(response.isNewUser()).isTrue();
@@ -119,12 +119,12 @@ class AuthServiceTest {
             given(blockedUser.getStatus()).willReturn(UserStatus.BLOCKED);
             OAuthUserInfo userInfo = new OAuthUserInfo(Provider.KAKAO, "kakao_blocked", "차단유저", null);
 
-            given(kakaoOAuthProvider.getUserInfo("auth_code")).willReturn(userInfo);
+            given(kakaoOAuthProvider.getUserInfo("auth_code", "http://localhost:8080/test.html")).willReturn(userInfo);
             given(userRepository.findByProviderAndProviderId(Provider.KAKAO, "kakao_blocked"))
                     .willReturn(Optional.of(blockedUser));
 
             // when & then
-            assertThatThrownBy(() -> authService.oauthLogin(Provider.KAKAO, "auth_code"))
+            assertThatThrownBy(() -> authService.oauthLogin(Provider.KAKAO, "auth_code", "http://localhost:8080/test.html"))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_BLOCKED);
         }
@@ -135,7 +135,7 @@ class AuthServiceTest {
             AuthService authService = createAuthService();
 
             // when & then
-            assertThatThrownBy(() -> authService.oauthLogin(Provider.NAVER, "auth_code"))
+            assertThatThrownBy(() -> authService.oauthLogin(Provider.NAVER, "auth_code", "http://localhost:8080/test.html"))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining("지원하지 않는 OAuth 제공자입니다");
         }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,7 +25,6 @@ oauth:
   kakao:
     client-id: test-kakao-client-id
     client-secret: test-kakao-client-secret
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
     allowed-redirect-uris:
       - http://localhost:8080/test.html
       - http://localhost:5173/oauth/kakao/callback

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,5 +26,8 @@ oauth:
     client-id: test-kakao-client-id
     client-secret: test-kakao-client-secret
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/test.html}
+    allowed-redirect-uris:
+      - http://localhost:8080/test.html
+      - http://localhost:5173/oauth/kakao/callback
     token-url: https://kauth.kakao.com/oauth/token
     user-info-url: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 💡 작업 내용

- [x] FE에서 redirect url을 request 보낼 수 있도록 하여 로컬과 서버환경 두 경우 모두 대응
- [x] 화이트 리스트 기반의 redirect url 추가

## 💡 자세한 설명
- redirect url 설정을 로컬과 개발환경 두 경우에 대응 되도록 수정하였습니다.

## ✅ 셀프 체크리스트

- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #33 
