### PR TITLE
feat: 공간 상세조회 시 히스토리 기록 및 조회 API 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/history/controller/HistoryController.java
+++ b/src/main/java/io/dnd/goyo/domain/history/controller/HistoryController.java
@@ -18,14 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "History", description = "조회 기록 관련 API")
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/histories")
 @RequiredArgsConstructor
 public class HistoryController {
 
     private final HistoryService historyService;
 
     @Operation(summary = "내 조회 기록 조회", description = "로그인한 사용자의 공간 조회 기록을 페이지네이션으로 조회합니다.")
-    @GetMapping("/histories/me")
+    @GetMapping("/me")
     public ResponseEntity<Page<HistoryItemResponse>> getMyHistories(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 10, sort = "viewedAt", direction = Sort.Direction.DESC) Pageable pageable

--- a/src/main/java/io/dnd/goyo/domain/history/controller/HistoryController.java
+++ b/src/main/java/io/dnd/goyo/domain/history/controller/HistoryController.java
@@ -1,0 +1,35 @@
+package io.dnd.goyo.domain.history.controller;
+
+import io.dnd.goyo.domain.history.dto.response.HistoryItemResponse;
+import io.dnd.goyo.domain.history.service.HistoryService;
+import io.dnd.goyo.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "History", description = "조회 기록 관련 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class HistoryController {
+
+    private final HistoryService historyService;
+
+    @Operation(summary = "내 조회 기록 조회", description = "로그인한 사용자의 공간 조회 기록을 페이지네이션으로 조회합니다.")
+    @GetMapping("/histories/me")
+    public ResponseEntity<Page<HistoryItemResponse>> getMyHistories(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 10, sort = "viewedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(historyService.getMyHistories(userDetails.userId(), pageable));
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/history/dto/response/HistoryItemResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/history/dto/response/HistoryItemResponse.java
@@ -1,0 +1,59 @@
+package io.dnd.goyo.domain.history.dto.response;
+
+import io.dnd.goyo.domain.history.entity.History;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.enums.Mood;
+import io.dnd.goyo.domain.place.enums.PlaceCategory;
+import io.dnd.goyo.domain.place.enums.SpaceSize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "조회 기록 아이템 응답")
+public record HistoryItemResponse(
+        @Schema(description = "기록 ID", example = "1")
+        Long historyId,
+        @Schema(description = "공간 ID", example = "10")
+        Long placeId,
+        @Schema(description = "공간 이름", example = "고작 아지트")
+        String placeName,
+        @Schema(description = "카테고리", example = "CAFE")
+        PlaceCategory category,
+        @Schema(description = "상세 주소", example = "청계천로 101")
+        String addressDetail,
+        @Schema(description = "행정구역 코드", example = "1168010100")
+        Long regionCode,
+        @Schema(description = "대표 이미지 키")
+        String representativeImageKey,
+        @Schema(description = "위도", example = "37.5665")
+        double latitude,
+        @Schema(description = "경도", example = "126.9780")
+        double longitude,
+        @Schema(description = "분위기", example = "CALM")
+        Mood mood,
+        @Schema(description = "공간 크기", example = "MEDIUM")
+        SpaceSize spaceSize,
+        @Schema(description = "조회 시각")
+        LocalDateTime viewedAt
+) {
+
+    public static HistoryItemResponse from(History history) {
+        Place place = history.getPlace();
+        PlaceDetail placeDetail = place.getPlaceDetail();
+
+        return new HistoryItemResponse(
+                history.getId(),
+                place.getId(),
+                place.getName(),
+                place.getCategory(),
+                place.getAddressDetail(),
+                place.getRegionCode().value(),
+                place.getRepresentativeImageKey(),
+                place.getLocation().getY(),
+                place.getLocation().getX(),
+                placeDetail != null ? placeDetail.getMood() : null,
+                placeDetail != null ? placeDetail.getSpaceSize() : null,
+                history.getViewedAt()
+        );
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/history/event/PlaceViewedEvent.java
+++ b/src/main/java/io/dnd/goyo/domain/history/event/PlaceViewedEvent.java
@@ -1,0 +1,6 @@
+package io.dnd.goyo.domain.history.event;
+
+public record PlaceViewedEvent(
+        Long userId,
+        Long placeId
+) {}

--- a/src/main/java/io/dnd/goyo/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,16 @@
+package io.dnd.goyo.domain.history.repository;
+
+import io.dnd.goyo.domain.history.entity.History;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
+
+    Optional<History> findByUserIdAndPlaceId(Long userId, Long placeId);
+
+    @EntityGraph(attributePaths = {"place", "place.placeDetail", "place.images"})
+    Page<History> findAllByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/io/dnd/goyo/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/history/repository/HistoryRepository.java
@@ -11,6 +11,6 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
 
     Optional<History> findByUserIdAndPlaceId(Long userId, Long placeId);
 
-    @EntityGraph(attributePaths = {"place", "place.placeDetail", "place.images"})
+    @EntityGraph(attributePaths = {"place", "place.placeDetail"})
     Page<History> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/io/dnd/goyo/domain/history/service/HistoryEventListener.java
+++ b/src/main/java/io/dnd/goyo/domain/history/service/HistoryEventListener.java
@@ -7,7 +7,6 @@ import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.place.service.PlaceReader;
 import io.dnd.goyo.domain.user.entity.User;
 import io.dnd.goyo.domain.user.service.UserReader;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -28,15 +27,17 @@ public class HistoryEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handlePlaceViewed(PlaceViewedEvent event) {
-        Optional<History> existing = historyRepository.findByUserIdAndPlaceId(
-                event.userId(), event.placeId());
-
-        if (existing.isPresent()) {
-            existing.get().updateViewedAt();
-        } else {
-            User user = userReader.getUser(event.userId());
-            Place place = placeReader.getPlace(event.placeId());
-            historyRepository.save(History.of(user, place));
+        try {
+            historyRepository.findByUserIdAndPlaceId(event.userId(), event.placeId())
+                    .ifPresentOrElse(
+                            History::updateViewedAt,
+                            () -> {
+                                User user = userReader.getUser(event.userId());
+                                Place place = placeReader.getPlace(event.placeId());
+                                historyRepository.save(History.of(user, place));
+                            });
+        } catch (Exception e) {
+            log.error("히스토리 저장 실패: userId={}, placeId={}", event.userId(), event.placeId(), e);
         }
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/history/service/HistoryEventListener.java
+++ b/src/main/java/io/dnd/goyo/domain/history/service/HistoryEventListener.java
@@ -1,0 +1,42 @@
+package io.dnd.goyo.domain.history.service;
+
+import io.dnd.goyo.domain.history.entity.History;
+import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
+import io.dnd.goyo.domain.history.repository.HistoryRepository;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.service.PlaceReader;
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.service.UserReader;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HistoryEventListener {
+
+    private final HistoryRepository historyRepository;
+    private final UserReader userReader;
+    private final PlaceReader placeReader;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handlePlaceViewed(PlaceViewedEvent event) {
+        Optional<History> existing = historyRepository.findByUserIdAndPlaceId(
+                event.userId(), event.placeId());
+
+        if (existing.isPresent()) {
+            existing.get().updateViewedAt();
+        } else {
+            User user = userReader.getUser(event.userId());
+            Place place = placeReader.getPlace(event.placeId());
+            historyRepository.save(History.of(user, place));
+        }
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/history/service/HistoryService.java
+++ b/src/main/java/io/dnd/goyo/domain/history/service/HistoryService.java
@@ -1,0 +1,22 @@
+package io.dnd.goyo.domain.history.service;
+
+import io.dnd.goyo.domain.history.dto.response.HistoryItemResponse;
+import io.dnd.goyo.domain.history.repository.HistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HistoryService {
+
+    private final HistoryRepository historyRepository;
+
+    public Page<HistoryItemResponse> getMyHistories(Long userId, Pageable pageable) {
+        return historyRepository.findAllByUserId(userId, pageable)
+                .map(HistoryItemResponse::from);
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import io.dnd.goyo.domain.place.repository.PlaceRepository;
 import io.dnd.goyo.domain.placetag.service.PlaceTagService;
 import io.dnd.goyo.domain.badge.enums.ActivityType;
 import io.dnd.goyo.domain.badge.event.ActivityEvent;
+import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
 import io.dnd.goyo.domain.user.entity.User;
 import io.dnd.goyo.domain.user.service.UserReader;
 import io.dnd.goyo.domain.wishlist.service.WishlistReader;
@@ -64,6 +65,10 @@ public class PlaceService {
         boolean isWished = false;
         if (userId != null) {
             isWished = wishlistReader.isWished(userId, placeId);
+        }
+
+        if (userId != null) {
+            eventPublisher.publishEvent(new PlaceViewedEvent(userId, placeId));
         }
 
         return PlaceDetailResponse.from(place, isWished, fileStorage);

--- a/src/test/java/io/dnd/goyo/domain/history/controller/HistoryControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/history/controller/HistoryControllerTest.java
@@ -13,6 +13,7 @@ import io.dnd.goyo.security.CustomUserDetails;
 import io.dnd.goyo.security.jwt.JwtTokenProvider;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,11 @@ class HistoryControllerTest {
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test

--- a/src/test/java/io/dnd/goyo/domain/history/controller/HistoryControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/history/controller/HistoryControllerTest.java
@@ -1,0 +1,76 @@
+package io.dnd.goyo.domain.history.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.dnd.goyo.domain.history.dto.response.HistoryItemResponse;
+import io.dnd.goyo.domain.history.service.HistoryService;
+import io.dnd.goyo.security.CustomUserDetails;
+import io.dnd.goyo.security.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HistoryController.class)
+class HistoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HistoryService historyService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        CustomUserDetails userDetails = CustomUserDetails.of(1L, "USER");
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    void 내_조회_기록_조회_성공_시_200_반환() throws Exception {
+        HistoryItemResponse response = new HistoryItemResponse(
+                1L, 10L, "테스트 카페", null, "서울시 강남구",
+                11110L, "image.jpg", 37.5, 127.0, null, null, LocalDateTime.now()
+        );
+        Page<HistoryItemResponse> page = new PageImpl<>(List.of(response));
+
+        given(historyService.getMyHistories(eq(1L), any(Pageable.class))).willReturn(page);
+
+        mockMvc.perform(get("/api/histories/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].historyId").value(1))
+                .andExpect(jsonPath("$.content[0].placeId").value(10))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void 조회_기록이_없으면_빈_페이지_반환() throws Exception {
+        Page<HistoryItemResponse> emptyPage = new PageImpl<>(List.of());
+
+        given(historyService.getMyHistories(eq(1L), any(Pageable.class))).willReturn(emptyPage);
+
+        mockMvc.perform(get("/api/histories/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/history/service/HistoryEventListenerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/history/service/HistoryEventListenerTest.java
@@ -1,0 +1,106 @@
+package io.dnd.goyo.domain.history.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.dnd.goyo.domain.history.entity.History;
+import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
+import io.dnd.goyo.domain.history.repository.HistoryRepository;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.service.PlaceReader;
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.service.UserReader;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryEventListenerTest {
+
+    @InjectMocks
+    private HistoryEventListener historyEventListener;
+
+    @Mock
+    private HistoryRepository historyRepository;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private PlaceReader placeReader;
+
+    @Nested
+    @DisplayName("공간 조회 이벤트 처리 시")
+    class HandlePlaceViewed {
+
+        @Test
+        void 기존_기록이_없으면_새로_생성() {
+            // given
+            Long userId = 1L;
+            Long placeId = 10L;
+            User user = mock(User.class);
+            Place place = mock(Place.class);
+
+            given(historyRepository.findByUserIdAndPlaceId(userId, placeId))
+                    .willReturn(Optional.empty());
+            given(userReader.getUser(userId)).willReturn(user);
+            given(placeReader.getPlace(placeId)).willReturn(place);
+
+            PlaceViewedEvent event = new PlaceViewedEvent(userId, placeId);
+
+            // when
+            historyEventListener.handlePlaceViewed(event);
+
+            // then
+            verify(historyRepository).save(any(History.class));
+        }
+
+        @Test
+        void 기존_기록이_있으면_viewedAt_갱신() {
+            // given
+            Long userId = 1L;
+            Long placeId = 10L;
+            History history = mock(History.class);
+
+            given(historyRepository.findByUserIdAndPlaceId(userId, placeId))
+                    .willReturn(Optional.of(history));
+
+            PlaceViewedEvent event = new PlaceViewedEvent(userId, placeId);
+
+            // when
+            historyEventListener.handlePlaceViewed(event);
+
+            // then
+            verify(history).updateViewedAt();
+            verify(historyRepository, never()).save(any(History.class));
+        }
+
+        @Test
+        void 기존_기록이_있으면_UserReader_PlaceReader_호출하지_않음() {
+            // given
+            Long userId = 1L;
+            Long placeId = 10L;
+            History history = mock(History.class);
+
+            given(historyRepository.findByUserIdAndPlaceId(userId, placeId))
+                    .willReturn(Optional.of(history));
+
+            PlaceViewedEvent event = new PlaceViewedEvent(userId, placeId);
+
+            // when
+            historyEventListener.handlePlaceViewed(event);
+
+            // then
+            verify(userReader, never()).getUser(any());
+            verify(placeReader, never()).getPlace(any());
+        }
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/history/service/HistoryServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/history/service/HistoryServiceTest.java
@@ -1,0 +1,111 @@
+package io.dnd.goyo.domain.history.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import io.dnd.goyo.domain.history.dto.response.HistoryItemResponse;
+import io.dnd.goyo.domain.history.entity.History;
+import io.dnd.goyo.domain.history.repository.HistoryRepository;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.entity.RegionCode;
+import io.dnd.goyo.domain.place.enums.PlaceCategory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryServiceTest {
+
+    @InjectMocks
+    private HistoryService historyService;
+
+    @Mock
+    private HistoryRepository historyRepository;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    @Nested
+    @DisplayName("내 조회 기록 조회")
+    class GetMyHistories {
+
+        @Test
+        void 조회_기록이_있으면_정상_반환() {
+            // given
+            Long userId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            History history = createMockHistory(1L, 10L);
+            Page<History> historyPage = new PageImpl<>(List.of(history));
+
+            given(historyRepository.findAllByUserId(eq(userId), any(Pageable.class)))
+                    .willReturn(historyPage);
+
+            // when
+            Page<HistoryItemResponse> result = historyService.getMyHistories(userId, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().historyId()).isEqualTo(1L);
+            assertThat(result.getContent().getFirst().placeId()).isEqualTo(10L);
+        }
+
+        @Test
+        void 조회_기록이_없으면_빈_페이지_반환() {
+            // given
+            Long userId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<History> emptyPage = new PageImpl<>(List.of());
+
+            given(historyRepository.findAllByUserId(eq(userId), any(Pageable.class)))
+                    .willReturn(emptyPage);
+
+            // when
+            Page<HistoryItemResponse> result = historyService.getMyHistories(userId, pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+        }
+
+        private History createMockHistory(Long historyId, Long placeId) {
+            Point location = geometryFactory.createPoint(new Coordinate(127.0, 37.5));
+
+            PlaceDetail placeDetail = mock(PlaceDetail.class);
+
+            Place place = mock(Place.class);
+            given(place.getId()).willReturn(placeId);
+            given(place.getName()).willReturn("테스트 카페");
+            given(place.getCategory()).willReturn(PlaceCategory.CAFE);
+            given(place.getAddressDetail()).willReturn("서울시 강남구");
+            given(place.getRegionCode()).willReturn(new RegionCode(1168010100L));
+            given(place.getRepresentativeImageKey()).willReturn("image.jpg");
+            given(place.getLocation()).willReturn(location);
+            given(place.getPlaceDetail()).willReturn(placeDetail);
+
+            History history = mock(History.class);
+            given(history.getId()).willReturn(historyId);
+            given(history.getPlace()).willReturn(place);
+            given(history.getViewedAt()).willReturn(LocalDateTime.now());
+
+            return history;
+        }
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.common.storage.FileStorage;
+import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
 import io.dnd.goyo.common.util.GeometryUtils;
 import io.dnd.goyo.domain.place.dto.request.PlaceImageRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceRegisterRequest;
@@ -164,6 +165,7 @@ class PlaceServiceTest {
 
             verify(placeRepository).findByIdWithDetails(placeId);
             verify(wishlistReader).isWished(userId, placeId);
+            verify(eventPublisher).publishEvent(any(PlaceViewedEvent.class));
         }
 
         @Test


### PR DESCRIPTION
## 💡 작업 내용
- [x] PlaceViewedEvent 이벤트 기반으로 히스토리 저장
- [x] AFTER_COMMIT + REQUIRES_NEW 트랜잭션으로 조회 API 실패 격리
- [x] upsert 방식으로 동일 공간 재조회 시 viewedAt만 갱신
- [x] GET /api/histories/me 페이지네이션 조회 API 추가
- [x] HistoryEventListener, HistoryService, HistoryController 테스트 추가

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #35 
