### PR TITLE
feat: 회원 탈퇴 시 탈퇴 사유 저장 기능 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
+++ b/src/main/java/io/dnd/goyo/domain/user/controller/UserController.java
@@ -6,20 +6,23 @@ import io.dnd.goyo.domain.user.dto.request.UpdateLocationConsentRequest;
 import io.dnd.goyo.domain.user.dto.request.UpdateNicknameRequest;
 import io.dnd.goyo.domain.user.dto.request.UpdateProfileImageRequest;
 import io.dnd.goyo.domain.user.dto.request.UpdateRegionRequest;
+import io.dnd.goyo.domain.user.dto.request.WithdrawRequest;
 import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
 import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.dto.response.WithdrawReasonResponse;
 import io.dnd.goyo.domain.user.service.UserService;
 import io.dnd.goyo.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,13 +47,21 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 유저의 계정을 탈퇴 처리합니다")
-    @DeleteMapping("/me")
+    @Operation(summary = "회원 탈퇴", description = "탈퇴 사유와 함께 현재 로그인한 유저의 계정을 탈퇴 처리합니다")
+    @PostMapping("/me/withdraw")
     public ResponseEntity<Void> withdraw(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody WithdrawRequest request
     ) {
-        userService.withdraw(userDetails.userId());
+        userService.withdraw(userDetails.userId(), request.reason(), request.detail());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "탈퇴 사유 목록 조회", description = "회원 탈퇴 시 선택 가능한 사유 목록을 조회합니다")
+    @GetMapping("/withdraw-reasons")
+    public ResponseEntity<List<WithdrawReasonResponse>> getWithdrawReasons() {
+        List<WithdrawReasonResponse> response = userService.getWithdrawReasons();
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "닉네임 중복 검사", description = "닉네임이 사용 가능한지 확인합니다")

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/WithdrawRequest.java
@@ -8,7 +8,7 @@ public record WithdrawRequest(
         @NotNull(message = "탈퇴 사유는 필수입니다")
         WithdrawReason reason,
 
-        @Size(max = 500, message = "상세 내용은 500자 이내여야 합니다")
+        @Size(max = 1000, message = "상세 내용은 1000자 이내여야 합니다")
         String detail
 ) {
 }

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,14 @@
+package io.dnd.goyo.domain.user.dto.request;
+
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record WithdrawRequest(
+        @NotNull(message = "탈퇴 사유는 필수입니다")
+        WithdrawReason reason,
+
+        @Size(max = 500, message = "상세 내용은 500자 이내여야 합니다")
+        String detail
+) {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/dto/response/WithdrawReasonResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/response/WithdrawReasonResponse.java
@@ -1,0 +1,12 @@
+package io.dnd.goyo.domain.user.dto.response;
+
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
+
+public record WithdrawReasonResponse(
+        String code,
+        String description
+) {
+    public static WithdrawReasonResponse from(WithdrawReason reason) {
+        return new WithdrawReasonResponse(reason.name(), reason.getDescription());
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
@@ -43,7 +43,7 @@ public class UserWithdraw extends BaseEntity {
     private String detail;
 
     private UserWithdraw(User user, WithdrawReason reason, String detail) {
-        validate(reason, detail);
+        validate(user, reason, detail);
         this.user = user;
         this.reason = reason;
         this.detail = detail;
@@ -53,7 +53,10 @@ public class UserWithdraw extends BaseEntity {
         return new UserWithdraw(user, reason, detail);
     }
 
-    private static void validate(WithdrawReason reason, String detail) {
+    private static void validate(User user, WithdrawReason reason, String detail) {
+        if (user == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "탈퇴 회원 정보는 필수입니다.");
+        }
         if (reason == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "탈퇴 사유는 필수입니다.");
         }

--- a/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
@@ -1,0 +1,68 @@
+package io.dnd.goyo.domain.user.entity;
+
+import io.dnd.goyo.common.entity.BaseEntity;
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_withdraws")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserWithdraw extends BaseEntity {
+
+    private static final int DETAIL_MAX_LENGTH = 1000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private WithdrawReason reason;
+
+    @Column(length = 500)
+    private String detail;
+
+    private UserWithdraw(User user, WithdrawReason reason, String detail) {
+        validate(reason, detail);
+        this.user = user;
+        this.reason = reason;
+        this.detail = detail;
+    }
+
+    public static UserWithdraw of(User user, WithdrawReason reason, String detail) {
+        return new UserWithdraw(user, reason, detail);
+    }
+
+    private static void validate(WithdrawReason reason, String detail) {
+        if (reason == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "탈퇴 사유는 필수입니다.");
+        }
+        if (reason == WithdrawReason.OTHER && (detail == null || detail.isBlank())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "기타 사유를 선택한 경우 상세 내용은 필수입니다.");
+        }
+        if (detail != null && detail.length() > DETAIL_MAX_LENGTH) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    String.format("상세 내용은 %d자 이내여야 합니다.", DETAIL_MAX_LENGTH));
+        }
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/UserWithdraw.java
@@ -39,7 +39,7 @@ public class UserWithdraw extends BaseEntity {
     @Column(nullable = false)
     private WithdrawReason reason;
 
-    @Column(length = 500)
+    @Column(length = 1000)
     private String detail;
 
     private UserWithdraw(User user, WithdrawReason reason, String detail) {

--- a/src/main/java/io/dnd/goyo/domain/user/enums/WithdrawReason.java
+++ b/src/main/java/io/dnd/goyo/domain/user/enums/WithdrawReason.java
@@ -1,0 +1,14 @@
+package io.dnd.goyo.domain.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithdrawReason {
+    LOW_USAGE("서비스를 자주 이용하지 않아요"),
+    PRIVACY_CONCERN("개인정보 보호가 걱정돼요"),
+    OTHER("기타(직접 입력)");
+
+    private final String description;
+}

--- a/src/main/java/io/dnd/goyo/domain/user/repository/UserWithdrawRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/user/repository/UserWithdrawRepository.java
@@ -1,0 +1,7 @@
+package io.dnd.goyo.domain.user.repository;
+
+import io.dnd.goyo.domain.user.entity.UserWithdraw;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserWithdrawRepository extends JpaRepository<UserWithdraw, Long> {
+}

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
@@ -4,11 +4,17 @@ import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
 import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.dto.response.WithdrawReasonResponse;
 import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.entity.UserWithdraw;
 import io.dnd.goyo.domain.user.enums.Gender;
 import io.dnd.goyo.domain.user.enums.UserStatus;
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
 import io.dnd.goyo.domain.user.repository.UserRepository;
+import io.dnd.goyo.domain.user.repository.UserWithdrawRepository;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +26,7 @@ public class UserService {
 
     private final UserReader userReader;
     private final UserRepository userRepository;
+    private final UserWithdrawRepository userWithdrawRepository;
 
     public UserProfileResponse getMyProfile(Long userId) {
         User user = userReader.getUser(userId);
@@ -74,8 +81,16 @@ public class UserService {
     }
 
     @Transactional
-    public void withdraw(Long userId) {
+    public void withdraw(Long userId, WithdrawReason reason, String detail) {
         User user = userReader.getUser(userId);
+        UserWithdraw userWithdraw = UserWithdraw.of(user, reason, detail);
+        userWithdrawRepository.save(userWithdraw);
         user.withdraw();
+    }
+
+    public List<WithdrawReasonResponse> getWithdrawReasons() {
+        return Arrays.stream(WithdrawReason.values())
+                .map(WithdrawReasonResponse::from)
+                .toList();
     }
 }

--- a/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
@@ -1,23 +1,27 @@
 package io.dnd.goyo.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
 import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.dto.response.WithdrawReasonResponse;
 import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
 import io.dnd.goyo.domain.user.service.UserService;
 import io.dnd.goyo.security.CustomUserDetails;
 import io.dnd.goyo.security.jwt.JwtTokenProvider;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -78,17 +82,76 @@ class UserControllerTest {
     }
 
     @Nested
-    @DisplayName("DELETE /api/users/me")
+    @DisplayName("POST /api/users/me/withdraw")
     class Withdraw {
 
         @Test
         void 회원_탈퇴_성공_시_204_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("reason", "LOW_USAGE"));
+
             // when & then
-            mockMvc.perform(delete("/api/users/me")
+            mockMvc.perform(post("/api/users/me/withdraw")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
                             .with(csrf()))
                     .andExpect(status().isNoContent());
 
-            verify(userService).withdraw(1L);
+            verify(userService).withdraw(eq(1L), eq(WithdrawReason.LOW_USAGE), isNull());
+        }
+
+        @Test
+        void 기타_사유로_탈퇴_성공_시_204_반환() throws Exception {
+            // given
+            String request = objectMapper.writeValueAsString(
+                    Map.of("reason", "OTHER", "detail", "다른 앱 사용"));
+
+            // when & then
+            mockMvc.perform(post("/api/users/me/withdraw")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isNoContent());
+
+            verify(userService).withdraw(eq(1L), eq(WithdrawReason.OTHER), eq("다른 앱 사용"));
+        }
+
+        @Test
+        void 사유_누락_시_400_반환() throws Exception {
+            // given
+            String request = "{}";
+
+            // when & then
+            mockMvc.perform(post("/api/users/me/withdraw")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request)
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/users/withdraw-reasons")
+    class GetWithdrawReasons {
+
+        @Test
+        void 탈퇴_사유_목록_조회_시_200_반환() throws Exception {
+            // given
+            List<WithdrawReasonResponse> reasons = List.of(
+                    WithdrawReasonResponse.from(WithdrawReason.LOW_USAGE),
+                    WithdrawReasonResponse.from(WithdrawReason.PRIVACY_CONCERN),
+                    WithdrawReasonResponse.from(WithdrawReason.OTHER)
+            );
+            given(userService.getWithdrawReasons()).willReturn(reasons);
+
+            // when & then
+            mockMvc.perform(get("/api/users/withdraw-reasons")
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()").value(3))
+                    .andExpect(jsonPath("$[0].code").value("LOW_USAGE"))
+                    .andExpect(jsonPath("$[2].code").value("OTHER"));
         }
     }
 

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
@@ -1,0 +1,118 @@
+package io.dnd.goyo.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.enums.Provider;
+import io.dnd.goyo.domain.user.enums.UserRole;
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserWithdrawTest {
+
+    private static User createValidUser() {
+        return User.builder()
+                .name("김고작")
+                .nickname("고작이")
+                .gender(Gender.MALE)
+                .provider(Provider.KAKAO)
+                .role(UserRole.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상적으로 UserWithdraw를 생성할 수 있다")
+    void 정상_생성() {
+        // given
+        User user = createValidUser();
+
+        // when
+        UserWithdraw withdraw = UserWithdraw.of(user, WithdrawReason.LOW_USAGE, null);
+
+        // then
+        assertThat(withdraw.getUser()).isEqualTo(user);
+        assertThat(withdraw.getReason()).isEqualTo(WithdrawReason.LOW_USAGE);
+        assertThat(withdraw.getDetail()).isNull();
+    }
+
+    @Test
+    @DisplayName("OTHER 사유에 상세 내용을 함께 생성할 수 있다")
+    void OTHER_사유_상세내용_포함() {
+        // given
+        User user = createValidUser();
+
+        // when
+        UserWithdraw withdraw = UserWithdraw.of(user, WithdrawReason.OTHER, "다른 앱을 사용하려고요");
+
+        // then
+        assertThat(withdraw.getReason()).isEqualTo(WithdrawReason.OTHER);
+        assertThat(withdraw.getDetail()).isEqualTo("다른 앱을 사용하려고요");
+    }
+
+    @Test
+    @DisplayName("reason이 null이면 예외가 발생한다")
+    void reason_null이면_예외() {
+        // given
+        User user = createValidUser();
+
+        // when & then
+        assertThatThrownBy(() -> UserWithdraw.of(user, null, null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("OTHER 사유인데 detail이 없으면 예외가 발생한다")
+    void OTHER_사유_detail_없으면_예외() {
+        // given
+        User user = createValidUser();
+
+        // when & then
+        assertThatThrownBy(() -> UserWithdraw.of(user, WithdrawReason.OTHER, null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("OTHER 사유인데 detail이 빈 문자열이면 예외가 발생한다")
+    void OTHER_사유_detail_빈문자열이면_예외() {
+        // given
+        User user = createValidUser();
+
+        // when & then
+        assertThatThrownBy(() -> UserWithdraw.of(user, WithdrawReason.OTHER, "   "))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("detail이 1000자를 초과하면 예외가 발생한다")
+    void detail_500자_초과_예외() {
+        // given
+        User user = createValidUser();
+        String longDetail = "a".repeat(1001);
+
+        // when & then
+        assertThatThrownBy(() -> UserWithdraw.of(user, WithdrawReason.OTHER, longDetail))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("detail이 정확히 500자이면 정상 생성된다")
+    void detail_500자_정상() {
+        // given
+        User user = createValidUser();
+        String detail = "a".repeat(500);
+
+        // when
+        UserWithdraw withdraw = UserWithdraw.of(user, WithdrawReason.OTHER, detail);
+
+        // then
+        assertThat(withdraw.getDetail()).hasSize(500);
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
@@ -90,8 +90,7 @@ class UserWithdrawTest {
     }
 
     @Test
-    @DisplayName("detail이 1000자를 초과하면 예외가 발생한다")
-    void detail_500자_초과_예외() {
+    void detail_1000자_초과_예외() {
         // given
         User user = createValidUser();
         String longDetail = "a".repeat(1001);
@@ -103,11 +102,10 @@ class UserWithdrawTest {
     }
 
     @Test
-    @DisplayName("detail이 정확히 500자이면 정상 생성된다")
-    void detail_500자_정상() {
+    void detail_1000자_정상() {
         // given
         User user = createValidUser();
-        String detail = "a".repeat(500);
+        String detail = "a".repeat(1000);
 
         // when
         UserWithdraw withdraw = UserWithdraw.of(user, WithdrawReason.OTHER, detail);

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserWithdrawTest.java
@@ -111,6 +111,6 @@ class UserWithdrawTest {
         UserWithdraw withdraw = UserWithdraw.of(user, WithdrawReason.OTHER, detail);
 
         // then
-        assertThat(withdraw.getDetail()).hasSize(500);
+        assertThat(withdraw.getDetail()).hasSize(1000);
     }
 }

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package io.dnd.goyo.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -9,13 +10,18 @@ import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.domain.user.dto.response.NicknameCheckResponse;
 import io.dnd.goyo.domain.user.dto.response.UserProfileResponse;
+import io.dnd.goyo.domain.user.dto.response.WithdrawReasonResponse;
 import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.entity.UserWithdraw;
 import io.dnd.goyo.domain.user.enums.Gender;
 import io.dnd.goyo.domain.user.enums.Provider;
 import io.dnd.goyo.domain.user.enums.UserRole;
 import io.dnd.goyo.domain.user.enums.UserStatus;
+import io.dnd.goyo.domain.user.enums.WithdrawReason;
 import io.dnd.goyo.domain.user.repository.UserRepository;
+import io.dnd.goyo.domain.user.repository.UserWithdrawRepository;
 import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,6 +41,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserWithdrawRepository userWithdrawRepository;
 
     private static User createValidUser() {
         return User.builder()
@@ -281,11 +290,43 @@ class UserServiceTest {
             given(userReader.getUser(userId)).willReturn(user);
 
             // when
-            userService.withdraw(userId);
+            userService.withdraw(userId, WithdrawReason.LOW_USAGE, null);
 
             // then
             assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
             assertThat(user.getNickname()).startsWith("deleted_");
+            verify(userWithdrawRepository).save(any(UserWithdraw.class));
+        }
+
+        @Test
+        void 기타_사유로_탈퇴_성공() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+
+            // when
+            userService.withdraw(userId, WithdrawReason.OTHER, "다른 앱을 사용하려고요");
+
+            // then
+            assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+            verify(userWithdrawRepository).save(any(UserWithdraw.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("탈퇴 사유 목록 조회")
+    class GetWithdrawReasons {
+
+        @Test
+        void 탈퇴_사유_목록_5개_반환() {
+            // when
+            List<WithdrawReasonResponse> reasons = userService.getWithdrawReasons();
+
+            // then
+            assertThat(reasons).hasSize(3);
+            assertThat(reasons.get(0).code()).isEqualTo("LOW_USAGE");
+            assertThat(reasons.get(2).code()).isEqualTo("OTHER");
         }
     }
 }

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -319,7 +319,7 @@ class UserServiceTest {
     class GetWithdrawReasons {
 
         @Test
-        void 탈퇴_사유_목록_5개_반환() {
+        void 탈퇴_사유_목록_조회_성공() {
             // when
             List<WithdrawReasonResponse> reasons = userService.getWithdrawReasons();
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] WithdrawReason Enum 및 UserWithdraw 엔티티 추가
- [x] DELETE /api/users/me -> POST /api/users/me/withdraw로 변경
  - 여러 클라이언트 대응을 위함 
- [x] GET /api/users/withdraw-reasons 탈퇴 사유 목록 조회 API 추가
- [x] OTHER 선택 시 상세 사유(detail) 필수 검증 적용

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #43
