### PR TITLE
feature: 공간 리뷰 등록 완료 시, 리뷰 순서 및 사진 조회 API 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/common/validation/Primaryable.java
+++ b/src/main/java/io/dnd/goyo/common/validation/Primaryable.java
@@ -1,0 +1,5 @@
+package io.dnd.goyo.common.validation;
+
+public interface Primaryable {
+    boolean isPrimary();
+}

--- a/src/main/java/io/dnd/goyo/common/validation/SinglePrimary.java
+++ b/src/main/java/io/dnd/goyo/common/validation/SinglePrimary.java
@@ -1,0 +1,17 @@
+package io.dnd.goyo.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SinglePrimaryValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SinglePrimary {
+    String message() default "대표 이미지는 최대 1개만 지정할 수 있습니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/io/dnd/goyo/common/validation/SinglePrimaryValidator.java
+++ b/src/main/java/io/dnd/goyo/common/validation/SinglePrimaryValidator.java
@@ -1,0 +1,18 @@
+package io.dnd.goyo.common.validation;
+
+import io.dnd.goyo.domain.review.dto.request.ReviewImageRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class SinglePrimaryValidator implements ConstraintValidator<SinglePrimary, List<ReviewImageRequest>> {
+
+    @Override
+    public boolean isValid(List<ReviewImageRequest> value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+        long primaryCount = value.stream().filter(ReviewImageRequest::isPrimary).count();
+        return primaryCount <= 1;
+    }
+}

--- a/src/main/java/io/dnd/goyo/common/validation/SinglePrimaryValidator.java
+++ b/src/main/java/io/dnd/goyo/common/validation/SinglePrimaryValidator.java
@@ -1,18 +1,17 @@
 package io.dnd.goyo.common.validation;
 
-import io.dnd.goyo.domain.review.dto.request.ReviewImageRequest;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.List;
 
-public class SinglePrimaryValidator implements ConstraintValidator<SinglePrimary, List<ReviewImageRequest>> {
+public class SinglePrimaryValidator implements ConstraintValidator<SinglePrimary, List<? extends Primaryable>> {
 
     @Override
-    public boolean isValid(List<ReviewImageRequest> value, ConstraintValidatorContext context) {
+    public boolean isValid(List<? extends Primaryable> value, ConstraintValidatorContext context) {
         if (value == null || value.isEmpty()) {
             return true;
         }
-        long primaryCount = value.stream().filter(ReviewImageRequest::isPrimary).count();
+        long primaryCount = value.stream().filter(Primaryable::isPrimary).count();
         return primaryCount <= 1;
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/place/repository/PlaceDetailRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/place/repository/PlaceDetailRepository.java
@@ -1,8 +1,10 @@
 package io.dnd.goyo.domain.place.repository;
 
 import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,10 @@ import org.springframework.data.repository.query.Param;
 public interface PlaceDetailRepository extends JpaRepository<PlaceDetail, Long> {
 
     Optional<PlaceDetail> findByPlaceId(Long placeId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pd FROM PlaceDetail pd WHERE pd.place.id = :placeId")
+    Optional<PlaceDetail> findByPlaceIdForUpdate(@Param("placeId") Long placeId);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PlaceDetail pd SET pd.wishCount = pd.wishCount + 1 WHERE pd.place.id = :placeId")

--- a/src/main/java/io/dnd/goyo/domain/review/controller/ReviewController.java
+++ b/src/main/java/io/dnd/goyo/domain/review/controller/ReviewController.java
@@ -40,8 +40,8 @@ public class ReviewController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody ReviewCreateRequest request
     ) {
-        Long reviewId = reviewService.createReview(userDetails.userId(), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ReviewCreateResponse.from(reviewId));
+        ReviewCreateResponse response = reviewService.createReview(userDetails.userId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "리뷰 단건 조회", description = "리뷰 상세 정보를 조회합니다.")

--- a/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewCreateRequest.java
@@ -2,6 +2,7 @@ package io.dnd.goyo.domain.review.dto.request;
 
 import io.dnd.goyo.common.validation.HalfStep;
 import io.dnd.goyo.common.validation.NoDuplicates;
+import io.dnd.goyo.common.validation.SinglePrimary;
 import io.dnd.goyo.domain.place.enums.CrowdStatus;
 import io.dnd.goyo.domain.place.enums.Mood;
 import io.dnd.goyo.domain.place.enums.OutletScore;
@@ -44,7 +45,7 @@ public record ReviewCreateRequest(
 
         String content,
 
-        @Valid @Size(max = 6, message = "리뷰 이미지는 최대 6개까지 등록할 수 있습니다") List<ReviewImageRequest> images,
+        @Valid @Size(max = 6, message = "리뷰 이미지는 최대 6개까지 등록할 수 있습니다") @SinglePrimary List<ReviewImageRequest> images,
 
         LocalDateTime visitedAt
 ) {

--- a/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewImageRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewImageRequest.java
@@ -1,5 +1,6 @@
 package io.dnd.goyo.domain.review.dto.request;
 
+import io.dnd.goyo.common.validation.Primaryable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -11,5 +12,5 @@ public record ReviewImageRequest(
         Integer sequence,
 
         boolean isPrimary
-) {
+) implements Primaryable {
 }

--- a/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/review/dto/request/ReviewUpdateRequest.java
@@ -2,6 +2,7 @@ package io.dnd.goyo.domain.review.dto.request;
 
 import io.dnd.goyo.common.validation.HalfStep;
 import io.dnd.goyo.common.validation.NoDuplicates;
+import io.dnd.goyo.common.validation.SinglePrimary;
 import io.dnd.goyo.domain.place.enums.CrowdStatus;
 import io.dnd.goyo.domain.place.enums.Mood;
 import io.dnd.goyo.domain.place.enums.OutletScore;
@@ -41,7 +42,7 @@ public record ReviewUpdateRequest(
 
         String content,
 
-        @Valid @Size(max = 6, message = "리뷰 이미지는 최대 6개까지 등록할 수 있습니다") List<ReviewImageRequest> images,
+        @Valid @Size(max = 6, message = "리뷰 이미지는 최대 6개까지 등록할 수 있습니다") @SinglePrimary List<ReviewImageRequest> images,
 
         LocalDateTime visitedAt
 ) {

--- a/src/main/java/io/dnd/goyo/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/review/dto/response/ReviewCreateResponse.java
@@ -1,10 +1,12 @@
 package io.dnd.goyo.domain.review.dto.response;
 
 public record ReviewCreateResponse(
-        Long reviewId
+        Long reviewId,
+        String representativeImageUrl,
+        long reviewOrder
 ) {
 
-    public static ReviewCreateResponse from(Long reviewId) {
-        return new ReviewCreateResponse(reviewId);
+    public static ReviewCreateResponse of(Long reviewId, String representativeImageUrl, long reviewOrder) {
+        return new ReviewCreateResponse(reviewId, representativeImageUrl, reviewOrder);
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/review/dto/response/ReviewCreateResponse.java
@@ -1,5 +1,8 @@
 package io.dnd.goyo.domain.review.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReviewCreateResponse(
         Long reviewId,
         String representativeImageUrl,

--- a/src/main/java/io/dnd/goyo/domain/review/entity/Review.java
+++ b/src/main/java/io/dnd/goyo/domain/review/entity/Review.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -27,7 +28,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "reviews")
+@Table(name = "reviews", indexes = {
+        @Index(name = "idx_review_place_status", columnList = "place_id, status")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {

--- a/src/main/java/io/dnd/goyo/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/review/repository/ReviewRepository.java
@@ -26,6 +26,4 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r JOIN FETCH r.user JOIN FETCH r.place WHERE r.id = :reviewId")
     Optional<Review> findByIdWithUserAndPlace(@Param("reviewId") Long reviewId);
 
-    @Query("SELECT COUNT(r) FROM Review r WHERE r.place.id = :placeId AND r.status = 'ACTIVE'")
-    long countByPlaceIdAndActiveStatus(@Param("placeId") Long placeId);
 }

--- a/src/main/java/io/dnd/goyo/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/review/repository/ReviewRepository.java
@@ -25,4 +25,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r JOIN FETCH r.user JOIN FETCH r.place WHERE r.id = :reviewId")
     Optional<Review> findByIdWithUserAndPlace(@Param("reviewId") Long reviewId);
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.place.id = :placeId AND r.status = 'ACTIVE'")
+    long countByPlaceIdAndActiveStatus(@Param("placeId") Long placeId);
 }

--- a/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
+++ b/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
@@ -74,7 +74,7 @@ public class ReviewService {
 
         reviewTagService.registerReviewTags(review, request.tagIds());
 
-        PlaceDetail placeDetail = getPlaceDetail(place.getId());
+        PlaceDetail placeDetail = getPlaceDetailForUpdate(place.getId());
         placeDetail.addReviewScores(ReviewScores.from(
                 request.rating().doubleValue(), request.outletScore(),
                 request.crowdStatus(), request.spaceSize(), request.mood()));
@@ -150,7 +150,7 @@ public class ReviewService {
         Review review = getActiveReview(reviewId);
         validateOwner(userId, review);
 
-        PlaceDetail placeDetail = getPlaceDetail(review.getPlace().getId());
+        PlaceDetail placeDetail = getPlaceDetailForUpdate(review.getPlace().getId());
         placeDetail.removeReviewScores(ReviewScores.from(review));
 
         review.update(
@@ -220,7 +220,7 @@ public class ReviewService {
 
         boolean hadImages = !reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId).isEmpty();
 
-        PlaceDetail placeDetail = getPlaceDetail(review.getPlace().getId());
+        PlaceDetail placeDetail = getPlaceDetailForUpdate(review.getPlace().getId());
         placeDetail.removeReviewScores(ReviewScores.from(review));
 
         review.delete();
@@ -248,6 +248,11 @@ public class ReviewService {
 
     private PlaceDetail getPlaceDetail(Long placeId) {
         return placeDetailRepository.findByPlaceId(placeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
+    }
+
+    private PlaceDetail getPlaceDetailForUpdate(Long placeId) {
+        return placeDetailRepository.findByPlaceIdForUpdate(placeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
     }
 

--- a/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
+++ b/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
@@ -9,7 +9,9 @@ import io.dnd.goyo.domain.place.entity.ReviewScores;
 import io.dnd.goyo.domain.place.repository.PlaceDetailRepository;
 import io.dnd.goyo.domain.place.service.PlaceReader;
 import io.dnd.goyo.domain.review.dto.request.ReviewCreateRequest;
+import io.dnd.goyo.domain.review.dto.request.ReviewImageRequest;
 import io.dnd.goyo.domain.review.dto.request.ReviewUpdateRequest;
+import io.dnd.goyo.domain.review.dto.response.ReviewCreateResponse;
 import io.dnd.goyo.domain.review.dto.response.ReviewDetailResponse;
 import io.dnd.goyo.domain.review.entity.Review;
 import io.dnd.goyo.domain.review.entity.ReviewImage;
@@ -53,7 +55,7 @@ public class ReviewService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public Long createReview(Long userId, ReviewCreateRequest request) {
+    public ReviewCreateResponse createReview(Long userId, ReviewCreateRequest request) {
         User user = userReader.getUser(userId);
         Place place = placeReader.getPlace(request.placeId());
 
@@ -80,7 +82,18 @@ public class ReviewService {
         boolean hasImages = request.images() != null && !request.images().isEmpty();
         eventPublisher.publishEvent(new ActivityEvent(userId, ActivityType.REVIEW, 1, hasImages ? 1 : 0));
 
-        return review.getId();
+        String representativeImageUrl = null;
+        if (request.images() != null) {
+            representativeImageUrl = request.images().stream()
+                    .filter(ReviewImageRequest::isPrimary)
+                    .findFirst()
+                    .map(img -> fileStorage.generatePublicUrl(img.imageKey()))
+                    .orElse(null);
+        }
+
+        long reviewOrder = reviewRepository.countByPlaceIdAndActiveStatus(place.getId());
+
+        return ReviewCreateResponse.of(review.getId(), representativeImageUrl, reviewOrder);
     }
 
     public ReviewDetailResponse getReview(Long reviewId) {

--- a/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
+++ b/src/main/java/io/dnd/goyo/domain/review/service/ReviewService.java
@@ -79,6 +79,8 @@ public class ReviewService {
                 request.rating().doubleValue(), request.outletScore(),
                 request.crowdStatus(), request.spaceSize(), request.mood()));
 
+        long reviewOrder = placeDetail.getReviewCount();
+
         boolean hasImages = request.images() != null && !request.images().isEmpty();
         eventPublisher.publishEvent(new ActivityEvent(userId, ActivityType.REVIEW, 1, hasImages ? 1 : 0));
 
@@ -90,8 +92,6 @@ public class ReviewService {
                     .map(img -> fileStorage.generatePublicUrl(img.imageKey()))
                     .orElse(null);
         }
-
-        long reviewOrder = reviewRepository.countByPlaceIdAndActiveStatus(place.getId());
 
         return ReviewCreateResponse.of(review.getId(), representativeImageUrl, reviewOrder);
     }

--- a/src/test/java/io/dnd/goyo/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/review/controller/ReviewControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dnd.goyo.domain.review.dto.request.ReviewCreateRequest;
+import io.dnd.goyo.domain.review.dto.response.ReviewCreateResponse;
 import io.dnd.goyo.domain.review.dto.request.ReviewUpdateRequest;
 import io.dnd.goyo.domain.review.dto.response.ReviewDetailResponse;
 import io.dnd.goyo.domain.review.service.ReviewService;
@@ -89,14 +90,16 @@ class ReviewControllerTest {
     @Test
     void 리뷰_작성_성공_시_201_반환() throws Exception {
         given(reviewService.createReview(eq(1L), any(ReviewCreateRequest.class)))
-                .willReturn(100L);
+                .willReturn(ReviewCreateResponse.of(100L, null, 1L));
 
         mockMvc.perform(post("/api/reviews")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(createValidCreateRequest()))
                         .with(csrf()))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.reviewId").value(100));
+                .andExpect(jsonPath("$.reviewId").value(100))
+                .andExpect(jsonPath("$.representativeImageUrl").doesNotExist())
+                .andExpect(jsonPath("$.reviewOrder").value(1));
 
         verify(reviewService).createReview(eq(1L), any(ReviewCreateRequest.class));
     }

--- a/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
@@ -127,7 +127,7 @@ class ReviewServiceTest {
 
             given(userReader.getUser(userId)).willReturn(user);
             given(placeReader.getPlace(placeId)).willReturn(place);
-            given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(placeId)).willReturn(Optional.of(placeDetail));
             given(placeDetail.getReviewCount()).willReturn(1);
 
             // when
@@ -163,7 +163,7 @@ class ReviewServiceTest {
 
             given(userReader.getUser(userId)).willReturn(user);
             given(placeReader.getPlace(placeId)).willReturn(place);
-            given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(placeId)).willReturn(Optional.of(placeDetail));
             given(placeDetail.getReviewCount()).willReturn(3);
             given(fileStorage.generatePublicUrl("img-key-1")).willReturn("https://cdn.example.com/img-key-1");
 
@@ -173,6 +173,37 @@ class ReviewServiceTest {
             // then
             assertThat(response.representativeImageUrl()).isEqualTo("https://cdn.example.com/img-key-1");
             assertThat(response.reviewOrder()).isEqualTo(3L);
+        }
+
+        @Test
+        void 이미지_포함하지만_대표_이미지_없을_시_대표_이미지_URL_null() {
+            // given
+            Long userId = 1L;
+            Long placeId = 10L;
+            User user = mock(User.class);
+            Place place = mock(Place.class);
+            given(place.getId()).willReturn(placeId);
+            PlaceDetail placeDetail = mock(PlaceDetail.class);
+
+            ReviewCreateRequest request = new ReviewCreateRequest(
+                    placeId, new BigDecimal("4.0"), List.of(1L, 2L), Mood.CALM, SpaceSize.MEDIUM,
+                    OutletScore.MANY, CrowdStatus.NORMAL, "좋은 카페입니다",
+                    List.of(new ReviewImageRequest("img-key-1", 0, false),
+                            new ReviewImageRequest("img-key-2", 1, false)),
+                    null
+            );
+
+            given(userReader.getUser(userId)).willReturn(user);
+            given(placeReader.getPlace(placeId)).willReturn(place);
+            given(placeDetailRepository.findByPlaceIdForUpdate(placeId)).willReturn(Optional.of(placeDetail));
+            given(placeDetail.getReviewCount()).willReturn(2);
+
+            // when
+            ReviewCreateResponse response = reviewService.createReview(userId, request);
+
+            // then
+            assertThat(response.representativeImageUrl()).isNull();
+            assertThat(response.reviewOrder()).isEqualTo(2L);
         }
 
         @Test
@@ -339,7 +370,7 @@ class ReviewServiceTest {
             ReviewUpdateRequest request = createReviewUpdateRequest();
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-            given(placeDetailRepository.findByPlaceId(10L)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(10L)).willReturn(Optional.of(placeDetail));
             given(reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId)).willReturn(List.of());
 
             // when
@@ -398,7 +429,7 @@ class ReviewServiceTest {
             );
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-            given(placeDetailRepository.findByPlaceId(10L)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(10L)).willReturn(Optional.of(placeDetail));
             given(reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId))
                     .willReturn(List.of(oldImage1, oldImage2));
 
@@ -433,7 +464,7 @@ class ReviewServiceTest {
             );
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-            given(placeDetailRepository.findByPlaceId(10L)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(10L)).willReturn(Optional.of(placeDetail));
             given(reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId))
                     .willReturn(List.of(oldImage));
             willThrow(new RuntimeException("MinIO 연결 실패"))
@@ -468,7 +499,7 @@ class ReviewServiceTest {
             );
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-            given(placeDetailRepository.findByPlaceId(10L)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(10L)).willReturn(Optional.of(placeDetail));
             given(reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId))
                     .willReturn(List.of(oldImage));
             willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "존재하지 않는 태그가 포함되어 있습니다."))
@@ -501,7 +532,7 @@ class ReviewServiceTest {
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
             given(reviewImageRepository.findAllByReviewIdOrderBySequence(reviewId)).willReturn(List.of());
-            given(placeDetailRepository.findByPlaceId(10L)).willReturn(Optional.of(placeDetail));
+            given(placeDetailRepository.findByPlaceIdForUpdate(10L)).willReturn(Optional.of(placeDetail));
 
             // when
             reviewService.deleteReview(userId, reviewId);

--- a/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
@@ -25,6 +25,7 @@ import io.dnd.goyo.domain.place.service.PlaceReader;
 import io.dnd.goyo.domain.review.dto.request.ReviewCreateRequest;
 import io.dnd.goyo.domain.review.dto.request.ReviewImageRequest;
 import io.dnd.goyo.domain.review.dto.request.ReviewUpdateRequest;
+import io.dnd.goyo.domain.review.dto.response.ReviewCreateResponse;
 import io.dnd.goyo.domain.review.dto.response.ReviewDetailResponse;
 import io.dnd.goyo.domain.review.entity.Review;
 import io.dnd.goyo.domain.review.entity.ReviewImage;
@@ -127,9 +128,10 @@ class ReviewServiceTest {
             given(userReader.getUser(userId)).willReturn(user);
             given(placeReader.getPlace(placeId)).willReturn(place);
             given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
+            given(reviewRepository.countByPlaceIdAndActiveStatus(placeId)).willReturn(1L);
 
             // when
-            reviewService.createReview(userId, request);
+            ReviewCreateResponse response = reviewService.createReview(userId, request);
 
             // then
             verify(reviewRepository).save(any(Review.class));
@@ -137,6 +139,40 @@ class ReviewServiceTest {
             verify(placeDetail).addReviewScores(ReviewScores.from(
                     request.rating().doubleValue(), request.outletScore(),
                     request.crowdStatus(), request.spaceSize(), request.mood()));
+            assertThat(response.representativeImageUrl()).isNull();
+            assertThat(response.reviewOrder()).isEqualTo(1L);
+        }
+
+        @Test
+        void 이미지_포함_리뷰_생성_시_대표_이미지_URL_반환() {
+            // given
+            Long userId = 1L;
+            Long placeId = 10L;
+            User user = mock(User.class);
+            Place place = mock(Place.class);
+            given(place.getId()).willReturn(placeId);
+            PlaceDetail placeDetail = mock(PlaceDetail.class);
+
+            ReviewCreateRequest request = new ReviewCreateRequest(
+                    placeId, new BigDecimal("4.0"), List.of(1L, 2L), Mood.CALM, SpaceSize.MEDIUM,
+                    OutletScore.MANY, CrowdStatus.NORMAL, "좋은 카페입니다",
+                    List.of(new ReviewImageRequest("img-key-1", 0, true),
+                            new ReviewImageRequest("img-key-2", 1, false)),
+                    null
+            );
+
+            given(userReader.getUser(userId)).willReturn(user);
+            given(placeReader.getPlace(placeId)).willReturn(place);
+            given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
+            given(reviewRepository.countByPlaceIdAndActiveStatus(placeId)).willReturn(3L);
+            given(fileStorage.generatePublicUrl("img-key-1")).willReturn("https://cdn.example.com/img-key-1");
+
+            // when
+            ReviewCreateResponse response = reviewService.createReview(userId, request);
+
+            // then
+            assertThat(response.representativeImageUrl()).isEqualTo("https://cdn.example.com/img-key-1");
+            assertThat(response.reviewOrder()).isEqualTo(3L);
         }
 
         @Test

--- a/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/review/service/ReviewServiceTest.java
@@ -128,7 +128,7 @@ class ReviewServiceTest {
             given(userReader.getUser(userId)).willReturn(user);
             given(placeReader.getPlace(placeId)).willReturn(place);
             given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
-            given(reviewRepository.countByPlaceIdAndActiveStatus(placeId)).willReturn(1L);
+            given(placeDetail.getReviewCount()).willReturn(1);
 
             // when
             ReviewCreateResponse response = reviewService.createReview(userId, request);
@@ -164,7 +164,7 @@ class ReviewServiceTest {
             given(userReader.getUser(userId)).willReturn(user);
             given(placeReader.getPlace(placeId)).willReturn(place);
             given(placeDetailRepository.findByPlaceId(placeId)).willReturn(Optional.of(placeDetail));
-            given(reviewRepository.countByPlaceIdAndActiveStatus(placeId)).willReturn(3L);
+            given(placeDetail.getReviewCount()).willReturn(3);
             given(fileStorage.generatePublicUrl("img-key-1")).willReturn("https://cdn.example.com/img-key-1");
 
             // when


### PR DESCRIPTION
## 💡 작업 내용
- [x]  공간 리뷰 등록 완료 시, API 구현

## 💡 자세한 설명
공간에 대한 리뷰가 등록되었을 때, 리뷰 순서와 사진을 확인할 수 있도록 API를 구현하였습니다.

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #52
