### PR TITLE
feat: 마이페이지에서 사용자의 리뷰 수, 등록한 공간 수, 뱃지 수 확인할 수 있도록 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -95,6 +95,8 @@ public class PlaceService {
         placeImageService.deleteAllImages(place, placeId);
         place.delete();
         wishlistService.deleteByPlaceId(placeId);
+
+        eventPublisher.publishEvent(new ActivityEvent(userId, ActivityType.PLACE, -1, -1));
     }
 
     private void validateOwner(Long userId, Place place) {

--- a/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/response/UserProfileResponse.java
@@ -1,6 +1,7 @@
 package io.dnd.goyo.domain.user.dto.response;
 
 import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.entity.UserStats;
 import io.dnd.goyo.domain.user.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -29,9 +30,18 @@ public record UserProfileResponse(
         Boolean locationConsent,
 
         @Schema(description = "거주지 행정구역 코드", example = "1168010100")
-        Long regionCode
+        Long regionCode,
+
+        @Schema(description = "리뷰 수", example = "5")
+        int reviewCount,
+
+        @Schema(description = "등록한 공간 수", example = "3")
+        int placeCount,
+
+        @Schema(description = "뱃지 수", example = "2")
+        int badgeCount
 ) {
-    public static UserProfileResponse from(User user) {
+    public static UserProfileResponse from(User user, UserStats userStats) {
         return new UserProfileResponse(
                 user.getId(),
                 user.getName(),
@@ -40,7 +50,10 @@ public record UserProfileResponse(
                 user.getGender(),
                 user.getProfileImg(),
                 user.getLocationConsent(),
-                user.getRegionCode()
+                user.getRegionCode(),
+                userStats.getReviewCount(),
+                userStats.getPlaceCount(),
+                userStats.getBadgeCount()
         );
     }
 }

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
@@ -11,7 +11,9 @@ import io.dnd.goyo.domain.user.entity.UserWithdraw;
 import io.dnd.goyo.domain.user.enums.Gender;
 import io.dnd.goyo.domain.user.enums.UserStatus;
 import io.dnd.goyo.domain.user.enums.WithdrawReason;
+import io.dnd.goyo.domain.user.entity.UserStats;
 import io.dnd.goyo.domain.user.repository.UserRepository;
+import io.dnd.goyo.domain.user.repository.UserStatsRepository;
 import io.dnd.goyo.domain.user.repository.UserWithdrawRepository;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -27,12 +29,15 @@ public class UserService {
 
     private final UserReader userReader;
     private final UserRepository userRepository;
+    private final UserStatsRepository userStatsRepository;
     private final UserWithdrawRepository userWithdrawRepository;
     private final FileStorage fileStorage;
 
     public UserProfileResponse getMyProfile(Long userId) {
         User user = userReader.getUser(userId);
-        return UserProfileResponse.from(user);
+        UserStats userStats = userStatsRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return UserProfileResponse.from(user, userStats);
     }
 
     public NicknameCheckResponse checkNickname(String nickname) {

--- a/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
+++ b/src/main/java/io/dnd/goyo/domain/user/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
     public UserProfileResponse getMyProfile(Long userId) {
         User user = userReader.getUser(userId);
         UserStats userStats = userStatsRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR));
         return UserProfileResponse.from(user, userStats);
     }
 

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.common.storage.FileStorage;
+import io.dnd.goyo.domain.badge.enums.ActivityType;
+import io.dnd.goyo.domain.badge.event.ActivityEvent;
 import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
 import io.dnd.goyo.common.util.GeometryUtils;
 import io.dnd.goyo.domain.place.dto.request.PlaceImageRequest;
@@ -334,6 +336,9 @@ class PlaceServiceTest {
             verify(placeImageService).deleteAllImages(place, placeId);
             verify(place).delete();
             verify(wishlistService).deleteByPlaceId(placeId);
+            verify(eventPublisher).publishEvent(
+                    new ActivityEvent(userId, ActivityType.PLACE, -1, -1)
+            );
         }
 
         @Test

--- a/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/controller/UserControllerTest.java
@@ -67,7 +67,7 @@ class UserControllerTest {
             // given
             UserProfileResponse response = new UserProfileResponse(
                     1L, "김고작", "고작이", LocalDate.of(1995, 3, 15),
-                    Gender.MALE, null, true, 1168010100L
+                    Gender.MALE, null, true, 1168010100L, 5, 3, 2
             );
             given(userService.getMyProfile(1L)).willReturn(response);
 

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -104,6 +104,20 @@ class UserServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
         }
+
+        @Test
+        void 사용자는_존재하지만_UserStats가_없으면_INTERNAL_SERVER_ERROR() {
+            // given
+            Long userId = 1L;
+            User user = createValidUser();
+            given(userReader.getUser(userId)).willReturn(user);
+            given(userStatsRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.getMyProfile(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     @Nested

--- a/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/service/UserServiceTest.java
@@ -19,10 +19,13 @@ import io.dnd.goyo.domain.user.enums.Provider;
 import io.dnd.goyo.domain.user.enums.UserRole;
 import io.dnd.goyo.domain.user.enums.UserStatus;
 import io.dnd.goyo.domain.user.enums.WithdrawReason;
+import io.dnd.goyo.domain.user.entity.UserStats;
 import io.dnd.goyo.domain.user.repository.UserRepository;
+import io.dnd.goyo.domain.user.repository.UserStatsRepository;
 import io.dnd.goyo.domain.user.repository.UserWithdrawRepository;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserStatsRepository userStatsRepository;
 
     @Mock
     private UserWithdrawRepository userWithdrawRepository;
@@ -70,7 +76,9 @@ class UserServiceTest {
             // given
             Long userId = 1L;
             User user = createValidUser();
+            UserStats userStats = UserStats.of(user);
             given(userReader.getUser(userId)).willReturn(user);
+            given(userStatsRepository.findByUserId(userId)).willReturn(Optional.of(userStats));
 
             // when
             UserProfileResponse response = userService.getMyProfile(userId);
@@ -79,6 +87,9 @@ class UserServiceTest {
             assertThat(response.name()).isEqualTo("김고작");
             assertThat(response.nickname()).isEqualTo("고작이");
             assertThat(response.gender()).isEqualTo(Gender.MALE);
+            assertThat(response.reviewCount()).isZero();
+            assertThat(response.placeCount()).isZero();
+            assertThat(response.badgeCount()).isZero();
         }
 
         @Test


### PR DESCRIPTION
## 💡 작업 내용
- [x] 사용자의 리뷰 수
- [x] 등록한 공간 수
- [x] 뱃지 수
- [x] 공간 삭제시 이벤트 발행하도록 추가

## 💡 자세한 설명
- 마이페이지에서 사용자의 리뷰 수, 등록한 공간 수, 뱃지 수 확인할 수 있도록 구현
    - `/api/users/me` 에 추가
- 공간 삭제시 이벤트 발행하도록 추가

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #53 
