### PR TITLE
refactor: 닉네임 및 태그 제약사항 수정

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/auth/dto/request/SignupRequest.java
@@ -20,7 +20,7 @@ public record SignupRequest(
 
         @Schema(description = "닉네임", example = "고요한여행자")
         @NotBlank(message = "닉네임은 필수입니다")
-        @Size(max = 30, message = "닉네임은 30자 이내여야 합니다")
+        @Size(max = 10, message = "닉네임은 10자 이내여야 합니다")
         String nickname,
 
         @Schema(description = "성별", example = "MALE")

--- a/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceRegisterRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceRegisterRequest.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
@@ -77,6 +78,8 @@ public record PlaceRegisterRequest(
         Mood mood,
 
         @Schema(description = "태그 ID 리스트", example = "[1, 5, 12]")
+        @NotNull(message = "태그는 필수입니다")
+        @Size(min = 2, max = 5, message = "태그는 2~5개 선택해야 합니다")
         List<Long> tagIds,
 
         @Schema(description = "업로드된 사진 리스트")

--- a/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceRegisterRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceRegisterRequest.java
@@ -11,6 +11,7 @@ import io.dnd.goyo.domain.place.enums.PlaceCategory;
 import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.dnd.goyo.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.dnd.goyo.common.validation.NoDuplicates;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -80,6 +81,7 @@ public record PlaceRegisterRequest(
         @Schema(description = "태그 ID 리스트", example = "[1, 5, 12]")
         @NotNull(message = "태그는 필수입니다")
         @Size(min = 2, max = 5, message = "태그는 2~5개 선택해야 합니다")
+        @NoDuplicates(message = "태그 ID는 중복될 수 없습니다")
         List<Long> tagIds,
 
         @Schema(description = "업로드된 사진 리스트")

--- a/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceUpdateRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceUpdateRequest.java
@@ -6,6 +6,7 @@ import io.dnd.goyo.domain.place.enums.Mood;
 import io.dnd.goyo.domain.place.enums.OutletScore;
 import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.dnd.goyo.common.validation.NoDuplicates;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -47,6 +48,7 @@ public record PlaceUpdateRequest(
         @Schema(description = "태그 ID 리스트", example = "[1, 5, 12]")
         @NotNull(message = "태그는 필수입니다")
         @Size(min = 2, max = 5, message = "태그는 2~5개 선택해야 합니다")
+        @NoDuplicates(message = "태그 ID는 중복될 수 없습니다")
         List<Long> tagIds,
 
         @Schema(description = "업로드된 사진 리스트")

--- a/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceUpdateRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/request/PlaceUpdateRequest.java
@@ -7,6 +7,7 @@ import io.dnd.goyo.domain.place.enums.OutletScore;
 import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalTime;
 import java.util.List;
@@ -44,6 +45,8 @@ public record PlaceUpdateRequest(
         CrowdStatus crowdStatus,
 
         @Schema(description = "태그 ID 리스트", example = "[1, 5, 12]")
+        @NotNull(message = "태그는 필수입니다")
+        @Size(min = 2, max = 5, message = "태그는 2~5개 선택해야 합니다")
         List<Long> tagIds,
 
         @Schema(description = "업로드된 사진 리스트")

--- a/src/main/java/io/dnd/goyo/domain/placetag/entity/PlaceTags.java
+++ b/src/main/java/io/dnd/goyo/domain/placetag/entity/PlaceTags.java
@@ -1,0 +1,42 @@
+package io.dnd.goyo.domain.placetag.entity;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+
+public record PlaceTags(List<Long> tagIds) {
+
+    private static final int MIN_SIZE = 2;
+    private static final int MAX_SIZE = 5;
+
+    public PlaceTags {
+        validateNotNull(tagIds);
+
+        List<Long> uniqueTagIds = tagIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        validateSize(uniqueTagIds.size());
+
+        tagIds = uniqueTagIds;
+    }
+
+    public static PlaceTags from(List<Long> tagIds) {
+        return new PlaceTags(tagIds);
+    }
+
+    private static void validateNotNull(List<Long> tagIds) {
+        if (tagIds == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "태그 목록은 필수입니다.");
+        }
+    }
+
+    private static void validateSize(int size) {
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    String.format("태그는 %d~%d개 선택해야 합니다.", MIN_SIZE, MAX_SIZE));
+        }
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/placetag/repository/PlaceTagRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/placetag/repository/PlaceTagRepository.java
@@ -38,6 +38,6 @@ public interface PlaceTagRepository extends JpaRepository<PlaceTag, Long> {
     List<Long> findTagIdsByPlaceId(@Param("placeId") Long placeId);
 
     @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM PlaceTag pt WHERE pt.place.id = :placeId AND pt.tag.id IN :tagIds")
-    void deleteByPlaceIdAndTagIdIn(@Param("placeId") Long placeId, @Param("tagIds") List<Long> tagIds);
+    @Query("DELETE FROM PlaceTag pt WHERE pt.place.id = :placeId")
+    void deleteAllByPlaceId(@Param("placeId") Long placeId);
 }

--- a/src/main/java/io/dnd/goyo/domain/placetag/service/PlaceTagService.java
+++ b/src/main/java/io/dnd/goyo/domain/placetag/service/PlaceTagService.java
@@ -4,12 +4,11 @@ import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.placetag.entity.PlaceTag;
+import io.dnd.goyo.domain.placetag.entity.PlaceTags;
 import io.dnd.goyo.domain.placetag.repository.PlaceTagRepository;
 import io.dnd.goyo.domain.tag.entity.Tag;
 import io.dnd.goyo.domain.tag.repository.TagRepository;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,56 +23,21 @@ public class PlaceTagService {
 
     @Transactional
     public void registerPlaceTags(Place place, List<Long> tagIds) {
-        if (tagIds == null || tagIds.isEmpty()) {
-            return;
-        }
+        PlaceTags placeTags = PlaceTags.from(tagIds);
 
-        List<Long> uniqueTagIds = tagIds.stream()
-                .distinct()
-                .toList();
+        List<Tag> tags = findAndValidateTags(placeTags.tagIds());
 
-        List<Tag> tags = findAndValidateTags(uniqueTagIds);
-
-        List<PlaceTag> placeTags = tags.stream()
+        List<PlaceTag> placeTagList = tags.stream()
                 .map(tag -> PlaceTag.of(place, tag))
                 .toList();
 
-        placeTagRepository.saveAll(placeTags);
+        placeTagRepository.saveAll(placeTagList);
     }
 
     @Transactional
     public void replacePlaceTags(Place place, List<Long> tagIds) {
-        if (tagIds == null) {
-            return;
-        }
-
-        Set<Long> newTagIds = new HashSet<>(tagIds);
-        Set<Long> existingTagIds = new HashSet<>(placeTagRepository.findTagIdsByPlaceId(place.getId()));
-
-        Set<Long> toRemove = new HashSet<>(existingTagIds);
-        toRemove.removeAll(newTagIds);
-
-        Set<Long> toAdd = new HashSet<>(newTagIds);
-        toAdd.removeAll(existingTagIds);
-
-        deleteTags(place.getId(), toRemove);
-        addTags(place, toAdd);
-    }
-
-    private void deleteTags(Long placeId, Set<Long> tagIdsToRemove) {
-        if (!tagIdsToRemove.isEmpty()) {
-            placeTagRepository.deleteByPlaceIdAndTagIdIn(placeId, List.copyOf(tagIdsToRemove));
-        }
-    }
-
-    private void addTags(Place place, Set<Long> tagIdsToAdd) {
-        if (!tagIdsToAdd.isEmpty()) {
-            List<Tag> tags = findAndValidateTags(List.copyOf(tagIdsToAdd));
-            List<PlaceTag> placeTags = tags.stream()
-                    .map(tag -> PlaceTag.of(place, tag))
-                    .toList();
-            placeTagRepository.saveAll(placeTags);
-        }
+        placeTagRepository.deleteAllByPlaceId(place.getId());
+        registerPlaceTags(place, tagIds);
     }
 
     private List<Tag> findAndValidateTags(List<Long> tagIds) {

--- a/src/main/java/io/dnd/goyo/domain/review/entity/ReviewTags.java
+++ b/src/main/java/io/dnd/goyo/domain/review/entity/ReviewTags.java
@@ -1,0 +1,42 @@
+package io.dnd.goyo.domain.review.entity;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import io.dnd.goyo.common.exception.ErrorCode;
+import java.util.List;
+import java.util.Objects;
+
+public record ReviewTags(List<Long> tagIds) {
+
+    private static final int MIN_SIZE = 2;
+    private static final int MAX_SIZE = 5;
+
+    public ReviewTags {
+        validateNotNull(tagIds);
+
+        List<Long> uniqueTagIds = tagIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        validateSize(uniqueTagIds.size());
+
+        tagIds = uniqueTagIds;
+    }
+
+    public static ReviewTags from(List<Long> tagIds) {
+        return new ReviewTags(tagIds);
+    }
+
+    private static void validateNotNull(List<Long> tagIds) {
+        if (tagIds == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "태그 목록은 필수입니다.");
+        }
+    }
+
+    private static void validateSize(int size) {
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    String.format("태그는 %d~%d개 선택해야 합니다.", MIN_SIZE, MAX_SIZE));
+        }
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/review/service/ReviewTagService.java
+++ b/src/main/java/io/dnd/goyo/domain/review/service/ReviewTagService.java
@@ -4,6 +4,7 @@ import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
 import io.dnd.goyo.domain.review.entity.Review;
 import io.dnd.goyo.domain.review.entity.ReviewTag;
+import io.dnd.goyo.domain.review.entity.ReviewTags;
 import io.dnd.goyo.domain.review.repository.ReviewTagRepository;
 import io.dnd.goyo.domain.tag.entity.Tag;
 import io.dnd.goyo.domain.tag.repository.TagRepository;
@@ -22,21 +23,15 @@ public class ReviewTagService {
 
     @Transactional
     public void registerReviewTags(Review review, List<Long> tagIds) {
-        if (tagIds == null || tagIds.isEmpty()) {
-            return;
-        }
+        ReviewTags reviewTags = ReviewTags.from(tagIds);
 
-        List<Long> uniqueTagIds = tagIds.stream()
-                .distinct()
-                .toList();
+        List<Tag> tags = findAndValidateTags(reviewTags.tagIds());
 
-        List<Tag> tags = findAndValidateTags(uniqueTagIds);
-
-        List<ReviewTag> reviewTags = tags.stream()
+        List<ReviewTag> reviewTagList = tags.stream()
                 .map(tag -> ReviewTag.of(review, tag))
                 .toList();
 
-        reviewTagRepository.saveAll(reviewTags);
+        reviewTagRepository.saveAll(reviewTagList);
     }
 
     @Transactional

--- a/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/io/dnd/goyo/domain/user/dto/request/UpdateNicknameRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size;
 public record UpdateNicknameRequest(
         @Schema(description = "닉네임", example = "고요한여행자")
         @NotBlank(message = "닉네임은 필수입니다")
-        @Size(max = 30, message = "닉네임은 30자 이내여야 합니다")
+        @Size(max = 10, message = "닉네임은 10자 이내여야 합니다")
         String nickname
 ) {
 }

--- a/src/main/java/io/dnd/goyo/domain/user/entity/User.java
+++ b/src/main/java/io/dnd/goyo/domain/user/entity/User.java
@@ -117,7 +117,7 @@ public class User extends BaseEntity {
     }
 
     private static final int NAME_MAX_LENGTH = 30;
-    private static final int NICKNAME_MAX_LENGTH = 30;
+    private static final int NICKNAME_MAX_LENGTH = 10;
 
     private static void validateName(String name) {
         if (name == null || name.isBlank()) {

--- a/src/test/java/io/dnd/goyo/domain/place/controller/PlaceControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/controller/PlaceControllerTest.java
@@ -78,6 +78,7 @@ class PlaceControllerTest {
                 Map.entry("spaceSize", "LARGE"),
                 Map.entry("crowdStatus", "RELAX"),
                 Map.entry("mood", "CALM"),
+                Map.entry("tagIds", List.of(1L, 2L, 3L)),
                 Map.entry("images", List.of(
                         Map.of("imageKey", "place/uuid.jpg", "sequence", 0, "isRepresentative", true),
                         Map.of("imageKey", "place/uuid2.jpg", "sequence", 1, "isRepresentative", false)
@@ -275,6 +276,7 @@ class PlaceControllerTest {
         private Map<String, Object> createValidUpdateRequest() {
             return Map.of(
                     "name", "수정된 카페",
+                    "tagIds", List.of(1L, 2L, 3L),
                     "images", List.of(
                             Map.of("imageKey", "place/uuid.jpg", "sequence", 0, "isRepresentative", true)
                     )
@@ -335,6 +337,7 @@ class PlaceControllerTest {
             Long placeId = 1L;
             Map<String, Object> request = new HashMap<>();
             request.put("name", "수정된 카페");
+            request.put("tagIds", List.of(1L, 2L, 3L));
             request.put("images", List.of());
 
             // when & then

--- a/src/test/java/io/dnd/goyo/domain/placetag/entity/PlaceTagsTest.java
+++ b/src/test/java/io/dnd/goyo/domain/placetag/entity/PlaceTagsTest.java
@@ -1,0 +1,96 @@
+package io.dnd.goyo.domain.placetag.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PlaceTagsTest {
+
+    @Nested
+    @DisplayName("PlaceTags 생성 시")
+    class CreatePlaceTags {
+
+        @Test
+        void 태그_목록이_null이면_예외_발생() {
+            assertThatThrownBy(() -> PlaceTags.from(null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그 목록은 필수입니다");
+        }
+
+        @Test
+        void 태그가_2개_미만이면_예외_발생() {
+            // given
+            List<Long> tagIds = createTagIds(1);
+
+            // when & then
+            assertThatThrownBy(() -> PlaceTags.from(tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그는 2~5개 선택해야 합니다");
+        }
+
+        @Test
+        void 태그가_5개_초과면_예외_발생() {
+            // given
+            List<Long> tagIds = createTagIds(6);
+
+            // when & then
+            assertThatThrownBy(() -> PlaceTags.from(tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그는 2~5개 선택해야 합니다");
+        }
+
+        @Test
+        void 태그_목록에_null이_포함되면_무시하고_생성() {
+            // given
+            List<Long> tagIds = new ArrayList<>(createTagIds(2));
+            tagIds.add(null);
+
+            // when
+            PlaceTags placeTags = PlaceTags.from(tagIds);
+
+            // then
+            assertThat(placeTags).isNotNull();
+            assertThat(placeTags.tagIds()).hasSize(2);
+        }
+
+        @Test
+        void 중복된_태그가_포함되면_제거하고_생성() {
+            // given
+            List<Long> tagIds = List.of(1L, 1L, 2L);
+
+            // when
+            PlaceTags placeTags = PlaceTags.from(tagIds);
+
+            // then
+            assertThat(placeTags).isNotNull();
+            assertThat(placeTags.tagIds()).hasSize(2);
+            assertThat(placeTags.tagIds()).containsExactly(1L, 2L);
+        }
+
+        @Test
+        void 정상적인_값으로_생성_가능() {
+            // given
+            List<Long> tagIds = createTagIds(3);
+
+            // when
+            PlaceTags placeTags = PlaceTags.from(tagIds);
+
+            // then
+            assertThat(placeTags).isNotNull();
+            assertThat(placeTags.tagIds()).hasSize(3);
+        }
+    }
+
+    private List<Long> createTagIds(int count) {
+        return LongStream.rangeClosed(1, count)
+                .boxed()
+                .toList();
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/placetag/service/PlaceTagServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/placetag/service/PlaceTagServiceTest.java
@@ -1,11 +1,8 @@
 package io.dnd.goyo.domain.placetag.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -16,6 +13,7 @@ import io.dnd.goyo.domain.placetag.repository.PlaceTagRepository;
 import io.dnd.goyo.domain.tag.entity.Tag;
 import io.dnd.goyo.domain.tag.repository.TagRepository;
 import java.util.List;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +36,43 @@ class PlaceTagServiceTest {
     private TagRepository tagRepository;
 
     @Nested
+    @DisplayName("태그 등록 시")
+    class RegisterPlaceTags {
+
+        private Place place;
+
+        @BeforeEach
+        void setUp() {
+            place = mock(Place.class);
+        }
+
+        @Test
+        void 정상적으로_태그가_등록된다() {
+            // given
+            List<Long> tagIds = createTagIds(3);
+            given(tagRepository.findAllById(tagIds)).willReturn(createTags(3));
+
+            // when
+            placeTagService.registerPlaceTags(place, tagIds);
+
+            // then
+            verify(placeTagRepository).saveAll(anyList());
+        }
+
+        @Test
+        void 존재하지_않는_태그_포함_시_예외_발생() {
+            // given
+            List<Long> tagIds = createTagIds(3);
+            given(tagRepository.findAllById(tagIds)).willReturn(createTags(2));
+
+            // when & then
+            assertThatThrownBy(() -> placeTagService.registerPlaceTags(place, tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("존재하지 않는 태그");
+        }
+    }
+
+    @Nested
     @DisplayName("태그 교체 시")
     class ReplacePlaceTags {
 
@@ -47,87 +82,52 @@ class PlaceTagServiceTest {
         @BeforeEach
         void setUp() {
             place = mock(Place.class);
-            lenient().when(place.getId()).thenReturn(placeId);
+            given(place.getId()).willReturn(placeId);
         }
 
         @Test
-        void 태그_목록이_null이면_아무_작업도_하지_않는다() {
-            // when
-            placeTagService.replacePlaceTags(place, null);
-
-            // then
-            verify(placeTagRepository, never()).findTagIdsByPlaceId(any());
-        }
-
-        @Test
-        void 새_태그만_추가되는_경우() {
+        void 기존_태그_삭제_후_새_태그가_등록된다() {
             // given
-            given(placeTagRepository.findTagIdsByPlaceId(placeId)).willReturn(List.of(1L, 2L));
-            Tag newTag = createTag();
-            given(tagRepository.findAllById(anyList())).willReturn(List.of(newTag));
+            List<Long> tagIds = createTagIds(3);
+            given(tagRepository.findAllById(tagIds)).willReturn(createTags(3));
 
             // when
-            placeTagService.replacePlaceTags(place, List.of(1L, 2L, 3L));
+            placeTagService.replacePlaceTags(place, tagIds);
 
             // then
-            verify(placeTagRepository, never()).deleteByPlaceIdAndTagIdIn(any(), any());
+            verify(placeTagRepository).deleteAllByPlaceId(placeId);
             verify(placeTagRepository).saveAll(anyList());
-        }
-
-        @Test
-        void 기존_태그만_삭제되는_경우() {
-            // given
-            given(placeTagRepository.findTagIdsByPlaceId(placeId)).willReturn(List.of(1L, 2L, 3L));
-
-            // when
-            placeTagService.replacePlaceTags(place, List.of(1L, 2L));
-
-            // then
-            verify(placeTagRepository).deleteByPlaceIdAndTagIdIn(eq(placeId), anyList());
-            verify(placeTagRepository, never()).saveAll(any());
-        }
-
-        @Test
-        void 태그_추가와_삭제가_동시에_일어나는_경우() {
-            // given
-            given(placeTagRepository.findTagIdsByPlaceId(placeId)).willReturn(List.of(1L, 2L));
-            Tag newTag = createTag();
-            given(tagRepository.findAllById(anyList())).willReturn(List.of(newTag));
-
-            // when
-            placeTagService.replacePlaceTags(place, List.of(2L, 3L));
-
-            // then
-            verify(placeTagRepository).deleteByPlaceIdAndTagIdIn(eq(placeId), anyList());
-            verify(placeTagRepository).saveAll(anyList());
-        }
-
-        @Test
-        void 동일한_태그로_업데이트_시_변경_없음() {
-            // given
-            given(placeTagRepository.findTagIdsByPlaceId(placeId)).willReturn(List.of(1L, 2L));
-
-            // when
-            placeTagService.replacePlaceTags(place, List.of(1L, 2L));
-
-            // then
-            verify(placeTagRepository, never()).deleteByPlaceIdAndTagIdIn(any(), any());
-            verify(placeTagRepository, never()).saveAll(any());
         }
 
         @Test
         void 존재하지_않는_태그_포함_시_예외_발생() {
             // given
-            given(placeTagRepository.findTagIdsByPlaceId(placeId)).willReturn(List.of(1L));
-            given(tagRepository.findAllById(anyList())).willReturn(List.of());
+            List<Long> tagIds = createTagIds(3);
+            given(tagRepository.findAllById(tagIds)).willReturn(createTags(2));
 
             // when & then
-            assertThatThrownBy(() -> placeTagService.replacePlaceTags(place, List.of(1L, 999L)))
-                    .isInstanceOf(BusinessException.class);
+            assertThatThrownBy(() -> placeTagService.replacePlaceTags(place, tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("존재하지 않는 태그");
         }
 
-        private Tag createTag() {
-            return mock(Tag.class);
+        @Test
+        void 태그_목록이_null이면_예외_발생() {
+            // when & then
+            assertThatThrownBy(() -> placeTagService.replacePlaceTags(place, null))
+                    .isInstanceOf(BusinessException.class);
         }
+    }
+
+    private List<Long> createTagIds(int count) {
+        return LongStream.rangeClosed(1, count)
+                .boxed()
+                .toList();
+    }
+
+    private List<Tag> createTags(int count) {
+        return LongStream.rangeClosed(1, count)
+                .mapToObj(i -> mock(Tag.class))
+                .toList();
     }
 }

--- a/src/test/java/io/dnd/goyo/domain/review/entity/ReviewTagsTest.java
+++ b/src/test/java/io/dnd/goyo/domain/review/entity/ReviewTagsTest.java
@@ -1,0 +1,96 @@
+package io.dnd.goyo.domain.review.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.dnd.goyo.common.exception.BusinessException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ReviewTagsTest {
+
+    @Nested
+    @DisplayName("ReviewTags 생성 시")
+    class CreateReviewTags {
+
+        @Test
+        void 태그_목록이_null이면_예외_발생() {
+            assertThatThrownBy(() -> ReviewTags.from(null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그 목록은 필수입니다");
+        }
+
+        @Test
+        void 태그가_2개_미만이면_예외_발생() {
+            // given
+            List<Long> tagIds = createTagIds(1);
+
+            // when & then
+            assertThatThrownBy(() -> ReviewTags.from(tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그는 2~5개 선택해야 합니다");
+        }
+
+        @Test
+        void 태그가_5개_초과면_예외_발생() {
+            // given
+            List<Long> tagIds = createTagIds(6);
+
+            // when & then
+            assertThatThrownBy(() -> ReviewTags.from(tagIds))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("태그는 2~5개 선택해야 합니다");
+        }
+
+        @Test
+        void 태그_목록에_null이_포함되면_무시하고_생성() {
+            // given
+            List<Long> tagIds = new ArrayList<>(createTagIds(2));
+            tagIds.add(null);
+
+            // when
+            ReviewTags reviewTags = ReviewTags.from(tagIds);
+
+            // then
+            assertThat(reviewTags).isNotNull();
+            assertThat(reviewTags.tagIds()).hasSize(2);
+        }
+
+        @Test
+        void 중복된_태그가_포함되면_제거하고_생성() {
+            // given
+            List<Long> tagIds = List.of(1L, 1L, 2L);
+
+            // when
+            ReviewTags reviewTags = ReviewTags.from(tagIds);
+
+            // then
+            assertThat(reviewTags).isNotNull();
+            assertThat(reviewTags.tagIds()).hasSize(2);
+            assertThat(reviewTags.tagIds()).containsExactly(1L, 2L);
+        }
+
+        @Test
+        void 정상적인_값으로_생성_가능() {
+            // given
+            List<Long> tagIds = createTagIds(3);
+
+            // when
+            ReviewTags reviewTags = ReviewTags.from(tagIds);
+
+            // then
+            assertThat(reviewTags).isNotNull();
+            assertThat(reviewTags.tagIds()).hasSize(3);
+        }
+    }
+
+    private List<Long> createTagIds(int count) {
+        return LongStream.rangeClosed(1, count)
+                .boxed()
+                .toList();
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
+++ b/src/test/java/io/dnd/goyo/domain/user/entity/UserTest.java
@@ -71,15 +71,15 @@ class UserTest {
         }
 
         @Test
-        void 닉네임이_30자를_초과하면_예외_발생() {
+        void 닉네임이_10자를_초과하면_예외_발생() {
             // given
             User.UserBuilder builder = createValidUserBuilder()
-                    .nickname("a".repeat(31));
+                    .nickname("a".repeat(11));
 
             // when & then
             assertThatThrownBy(builder::build)
                     .isInstanceOf(BusinessException.class)
-                    .hasMessageContaining("닉네임은 30자 이내여야 합니다");
+                    .hasMessageContaining("닉네임은 10자 이내여야 합니다");
         }
 
         @Test
@@ -198,14 +198,14 @@ class UserTest {
         }
 
         @Test
-        void 닉네임이_30자를_초과하면_예외_발생() {
+        void 닉네임이_10자를_초과하면_예외_발생() {
             // given
             User user = createValidUserBuilder().build();
 
             // when & then
-            assertThatThrownBy(() -> user.updateNickname("a".repeat(31)))
+            assertThatThrownBy(() -> user.updateNickname("a".repeat(11)))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessageContaining("닉네임은 30자 이내여야 합니다");
+                    .hasMessageContaining("닉네임은 10자 이내여야 합니다");
         }
     }
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 닉네임 제한 영문, 숫자, 한글 등 상관없이 10글자로 제한
- [x] 태그 최소 2개 최대 5개 검증 추가

## 💡 자세한 설명
<!--구현한 의도를 설명해주세요. 수정 사항이 있다면 수정한 이유를 적어주세요. 필요하다면 스크린샷 또는 코드 조각을 사용해주세요.-->
태그 개수 제약(2~5개)을 `PlaceTags`, `ReviewTags` 일급 컬렉션에서 담당하도록 수정했습니다.
리뷰와 공간 태그 수정 방식도 통일했습니다.

## ✅ 셀프 체크리스트

- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #46 
