### PR TITLE
feat: 등록 공간 히스토리 조회 구현

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/place/controller/PlaceController.java
+++ b/src/main/java/io/dnd/goyo/domain/place/controller/PlaceController.java
@@ -4,19 +4,25 @@ import io.dnd.goyo.domain.place.dto.request.NearbyFilterRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceFilterRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceRegisterRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceUpdateRequest;
+import io.dnd.goyo.domain.place.dto.response.MyPlaceResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceDetailResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceFilterResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceMapItemResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceRegisterResponse;
+import io.dnd.goyo.domain.place.enums.PlaceSortType;
 import io.dnd.goyo.domain.place.service.PlaceSearchService;
 import io.dnd.goyo.domain.place.service.PlaceService;
 import io.dnd.goyo.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Size;
 import org.springdoc.core.annotations.ParameterObject;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -57,6 +63,18 @@ public class PlaceController {
     ) {
         PlaceFilterResponse response = placeSearchService.getNearbyFilteredPlaces(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 등록 공간 조회", description = "로그인한 사용자가 등록한 공간 목록을 페이지네이션으로 조회합니다. 정렬은 sortType 파라미터를 사용하세요.")
+    @GetMapping("/me")
+    public ResponseEntity<Page<MyPlaceResponse>> getMyPlaces(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "페이지 번호(page)와 크기(size)만 사용. sort는 sortType 파라미터로 대체됩니다.")
+            @PageableDefault(size = 10) Pageable pageable,
+            @Parameter(description = "정렬 조건: LATEST(최신순), NAME(이름순), POPULAR(인기순)")
+            @RequestParam(defaultValue = "LATEST") PlaceSortType sortType
+    ) {
+        return ResponseEntity.ok(placeService.getMyPlaces(userDetails.userId(), pageable, sortType));
     }
 
     @Operation(summary = "공간 일괄 조회", description = "ID 목록으로 공간을 일괄 조회합니다.")

--- a/src/main/java/io/dnd/goyo/domain/place/dto/response/MyPlaceResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/response/MyPlaceResponse.java
@@ -1,0 +1,41 @@
+package io.dnd.goyo.domain.place.dto.response;
+
+import io.dnd.goyo.common.storage.FileStorage;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.enums.Mood;
+import io.dnd.goyo.domain.place.enums.SpaceSize;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 등록 공간 아이템 응답")
+public record MyPlaceResponse(
+        @Schema(description = "공간 ID", example = "1")
+        Long placeId,
+        @Schema(description = "공간 이름", example = "고작 아지트")
+        String placeName,
+        @Schema(description = "대표 이미지 URL")
+        String representativeImageUrl,
+        @Schema(description = "분위기", example = "CALM")
+        Mood mood,
+        @Schema(description = "공간 크기", example = "MEDIUM")
+        SpaceSize spaceSize,
+        @Schema(description = "찜 수", example = "42")
+        int wishCount,
+        @Schema(description = "찜 여부", example = "true")
+        boolean wished
+) {
+
+    public static MyPlaceResponse from(Place place, boolean wished, FileStorage fileStorage) {
+        PlaceDetail placeDetail = place.getPlaceDetail();
+
+        return new MyPlaceResponse(
+                place.getId(),
+                place.getName(),
+                fileStorage.generatePublicUrl(place.getRepresentativeImageKey()),
+                placeDetail.getMood(),
+                placeDetail.getSpaceSize(),
+                placeDetail.getWishCount(),
+                wished
+        );
+    }
+}

--- a/src/main/java/io/dnd/goyo/domain/place/enums/PlaceSortType.java
+++ b/src/main/java/io/dnd/goyo/domain/place/enums/PlaceSortType.java
@@ -1,0 +1,39 @@
+package io.dnd.goyo.domain.place.enums;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public enum PlaceSortType {
+    LATEST("createdAt", Sort.Direction.DESC) {
+        @Override
+        public Sort toSort() {
+            return Sort.by(getDirection(), getProperty());
+        }
+    },
+    NAME("name", Sort.Direction.ASC) {
+        @Override
+        public Sort toSort() {
+            return Sort.by(
+                    new Sort.Order(getDirection(), getProperty()),
+                    new Sort.Order(Sort.Direction.DESC, "createdAt")
+            );
+        }
+    },
+    POPULAR(null, null) {
+        @Override
+        public Sort toSort() {
+            return Sort.unsorted();
+        }
+    };
+
+    private final String property;
+    private final Sort.Direction direction;
+
+    PlaceSortType(String property, Sort.Direction direction) {
+        this.property = property;
+        this.direction = direction;
+    }
+
+    public abstract Sort toSort();
+}

--- a/src/main/java/io/dnd/goyo/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/place/repository/PlaceRepository.java
@@ -1,8 +1,12 @@
 package io.dnd.goyo.domain.place.repository;
 
 import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.enums.PlaceStatus;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -75,4 +79,12 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
             @Param("priorRating") double priorRating,
             @Param("limit") int limit
     );
+
+    @EntityGraph(attributePaths = {"placeDetail", "images"})
+    Page<Place> findAllByUserIdAndStatus(@Param("userId") Long userId, PlaceStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"placeDetail", "images"})
+    @Query(value = "SELECT p FROM Place p JOIN p.placeDetail pd WHERE p.user.id = :userId AND p.status = 'ACTIVE' ORDER BY pd.wishCount DESC, p.createdAt DESC",
+           countQuery = "SELECT COUNT(p) FROM Place p WHERE p.user.id = :userId AND p.status = 'ACTIVE'")
+    Page<Place> findAllByUserIdOrderByWishCountDesc(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/io/dnd/goyo/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/place/repository/PlaceRepository.java
@@ -80,11 +80,11 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
             @Param("limit") int limit
     );
 
-    @EntityGraph(attributePaths = {"placeDetail", "images"})
-    Page<Place> findAllByUserIdAndStatus(@Param("userId") Long userId, PlaceStatus status, Pageable pageable);
+    @Query(value = "SELECT p.id FROM Place p WHERE p.user.id = :userId AND p.status = :status",
+           countQuery = "SELECT COUNT(p) FROM Place p WHERE p.user.id = :userId AND p.status = :status")
+    Page<Long> findIdsByUserIdAndStatus(@Param("userId") Long userId, @Param("status") PlaceStatus status, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"placeDetail", "images"})
-    @Query(value = "SELECT p FROM Place p JOIN p.placeDetail pd WHERE p.user.id = :userId AND p.status = 'ACTIVE' ORDER BY pd.wishCount DESC, p.createdAt DESC",
+    @Query(value = "SELECT p.id FROM Place p JOIN p.placeDetail pd WHERE p.user.id = :userId AND p.status = 'ACTIVE' ORDER BY pd.wishCount DESC, p.createdAt DESC",
            countQuery = "SELECT COUNT(p) FROM Place p WHERE p.user.id = :userId AND p.status = 'ACTIVE'")
-    Page<Place> findAllByUserIdOrderByWishCountDesc(@Param("userId") Long userId, Pageable pageable);
+    Page<Long> findIdsByUserIdOrderByWishCountDesc(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -20,7 +20,10 @@ import io.dnd.goyo.domain.badge.event.ActivityEvent;
 import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
 import io.dnd.goyo.domain.user.entity.User;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -110,18 +113,24 @@ public class PlaceService {
 
     public Page<MyPlaceResponse> getMyPlaces(Long userId, Pageable pageable, PlaceSortType sortType) {
         PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        Page<Place> placePage;
+        Page<Long> idPage;
         if (sortType == PlaceSortType.POPULAR) {
-            placePage = placeRepository.findAllByUserIdOrderByWishCountDesc(userId, pageRequest);
+            idPage = placeRepository.findIdsByUserIdOrderByWishCountDesc(userId, pageRequest);
         } else {
-            placePage = placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, pageRequest.withSort(sortType.toSort()));
+            idPage = placeRepository.findIdsByUserIdAndStatus(userId, PlaceStatus.ACTIVE, pageRequest.withSort(sortType.toSort()));
         }
 
-        List<Long> placeIds = placePage.map(Place::getId).toList();
+        List<Long> placeIds = idPage.getContent();
+        List<Place> places = placeRepository.findAllByIdWithDetails(placeIds);
+
+        Map<Long, Place> placeMap = places.stream().collect(Collectors.toMap(Place::getId, p -> p));
         Set<Long> wishedPlaceIds = wishlistReader.getWishedPlaceIdSet(userId, placeIds);
 
-        return placePage.map(place ->
-                MyPlaceResponse.from(place, wishedPlaceIds.contains(place.getId()), fileStorage));
+        List<MyPlaceResponse> responses = placeIds.stream()
+                .map(id -> MyPlaceResponse.from(placeMap.get(id), wishedPlaceIds.contains(id), fileStorage))
+                .toList();
+
+        return new PageImpl<>(responses, pageRequest, idPage.getTotalElements());
     }
 
     public List<PlaceMapItemResponse> getPlacesByIds(List<Long> ids) {

--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -6,10 +6,13 @@ import io.dnd.goyo.common.storage.FileStorage;
 import io.dnd.goyo.common.util.GeometryUtils;
 import io.dnd.goyo.domain.place.dto.request.PlaceRegisterRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceUpdateRequest;
+import io.dnd.goyo.domain.place.dto.response.MyPlaceResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceDetailResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceMapItemResponse;
 import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.enums.PlaceSortType;
+import io.dnd.goyo.domain.place.enums.PlaceStatus;
 import io.dnd.goyo.domain.place.repository.PlaceRepository;
 import io.dnd.goyo.domain.placetag.service.PlaceTagService;
 import io.dnd.goyo.domain.badge.enums.ActivityType;
@@ -18,6 +21,9 @@ import io.dnd.goyo.domain.history.event.PlaceViewedEvent;
 import io.dnd.goyo.domain.user.entity.User;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import io.dnd.goyo.domain.user.service.UserReader;
 import io.dnd.goyo.domain.wishlist.service.WishlistReader;
 import io.dnd.goyo.domain.wishlist.service.WishlistService;
@@ -100,6 +106,22 @@ public class PlaceService {
         wishlistService.deleteByPlaceId(placeId);
 
         eventPublisher.publishEvent(new ActivityEvent(userId, ActivityType.PLACE, -1, -1));
+    }
+
+    public Page<MyPlaceResponse> getMyPlaces(Long userId, Pageable pageable, PlaceSortType sortType) {
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        Page<Place> placePage;
+        if (sortType == PlaceSortType.POPULAR) {
+            placePage = placeRepository.findAllByUserIdOrderByWishCountDesc(userId, pageRequest);
+        } else {
+            placePage = placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, pageRequest.withSort(sortType.toSort()));
+        }
+
+        List<Long> placeIds = placePage.map(Place::getId).toList();
+        Set<Long> wishedPlaceIds = wishlistReader.getWishedPlaceIdSet(userId, placeIds);
+
+        return placePage.map(place ->
+                MyPlaceResponse.from(place, wishedPlaceIds.contains(place.getId()), fileStorage));
     }
 
     public List<PlaceMapItemResponse> getPlacesByIds(List<Long> ids) {

--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -127,6 +127,7 @@ public class PlaceService {
         Set<Long> wishedPlaceIds = wishlistReader.getWishedPlaceIdSet(userId, placeIds);
 
         List<MyPlaceResponse> responses = placeIds.stream()
+                .filter(placeMap::containsKey)
                 .map(id -> MyPlaceResponse.from(placeMap.get(id), wishedPlaceIds.contains(id), fileStorage))
                 .toList();
 

--- a/src/main/java/io/dnd/goyo/domain/wishlist/dto/response/WishlistItemResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/wishlist/dto/response/WishlistItemResponse.java
@@ -1,9 +1,9 @@
 package io.dnd.goyo.domain.wishlist.dto.response;
 
+import io.dnd.goyo.common.storage.FileStorage;
 import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.place.entity.PlaceDetail;
 import io.dnd.goyo.domain.place.enums.Mood;
-import io.dnd.goyo.domain.place.enums.PlaceCategory;
 import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.dnd.goyo.domain.wishlist.entity.Wishlist;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,27 +17,21 @@ public record WishlistItemResponse(
         Long placeId,
         @Schema(description = "공간 이름", example = "고작 아지트")
         String placeName,
-        @Schema(description = "카테고리", example = "CAFE")
-        PlaceCategory category,
-        @Schema(description = "상세 주소", example = "청계천로 101")
-        String addressDetail,
-        @Schema(description = "행정구역 코드", example = "1168010100")
-        Long regionCode,
-        @Schema(description = "대표 이미지 키")
-        String representativeImageKey,
-        @Schema(description = "위도", example = "37.5665")
-        double latitude,
-        @Schema(description = "경도", example = "126.9780")
-        double longitude,
+        @Schema(description = "대표 이미지 URL")
+        String representativeImageUrl,
         @Schema(description = "분위기", example = "CALM")
         Mood mood,
         @Schema(description = "공간 크기", example = "MEDIUM")
         SpaceSize spaceSize,
+        @Schema(description = "찜 수", example = "42")
+        int wishCount,
+        @Schema(description = "찜 여부", example = "true")
+        boolean wished,
         @Schema(description = "찜한 시각")
         LocalDateTime wishedAt
 ) {
 
-    public static WishlistItemResponse from(Wishlist wishlist) {
+    public static WishlistItemResponse from(Wishlist wishlist, FileStorage fileStorage) {
         Place place = wishlist.getPlace();
         PlaceDetail placeDetail = place.getPlaceDetail();
 
@@ -45,14 +39,11 @@ public record WishlistItemResponse(
                 wishlist.getId(),
                 place.getId(),
                 place.getName(),
-                place.getCategory(),
-                place.getAddressDetail(),
-                place.getRegionCode().getValue(),
-                place.getRepresentativeImageKey(),
-                place.getLocation().getY(),
-                place.getLocation().getX(),
-                placeDetail != null ? placeDetail.getMood() : null,
-                placeDetail != null ? placeDetail.getSpaceSize() : null,
+                fileStorage.generatePublicUrl(place.getRepresentativeImageKey()),
+                placeDetail.getMood(),
+                placeDetail.getSpaceSize(),
+                placeDetail.getWishCount(),
+                true,
                 wishlist.getCreatedAt()
         );
     }

--- a/src/main/java/io/dnd/goyo/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/io/dnd/goyo/domain/wishlist/repository/WishlistRepository.java
@@ -43,7 +43,7 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
 
     @EntityGraph(attributePaths = {"place", "place.placeDetail", "place.images"})
     @Query(value = "SELECT w FROM Wishlist w JOIN w.place p JOIN p.placeDetail pd WHERE w.user.id = :userId ORDER BY pd.wishCount DESC, w.createdAt DESC",
-           countQuery = "SELECT COUNT(w) FROM Wishlist w WHERE w.user.id = :userId")
+           countQuery = "SELECT COUNT(w) FROM Wishlist w JOIN w.place p JOIN p.placeDetail pd WHERE w.user.id = :userId")
     Page<Wishlist> findAllByUserIdOrderByWishCountDesc(@Param("userId") Long userId, Pageable pageable);
 
     @Query(value = """

--- a/src/main/java/io/dnd/goyo/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/io/dnd/goyo/domain/wishlist/service/WishlistService.java
@@ -2,6 +2,7 @@ package io.dnd.goyo.domain.wishlist.service;
 
 import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.common.storage.FileStorage;
 import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.place.entity.PlaceDetail;
 import io.dnd.goyo.domain.place.repository.PlaceDetailRepository;
@@ -31,6 +32,7 @@ public class WishlistService {
     private final UserReader userReader;
     private final PlaceReader placeReader;
     private final WishlistReader wishlistReader;
+    private final FileStorage fileStorage;
 
     @Transactional
     public void deleteByPlaceId(Long placeId) {
@@ -62,7 +64,7 @@ public class WishlistService {
         } else {
             wishlistPage = wishlistRepository.findAllByUserId(userId, pageRequest.withSort(sortType.toSort()));
         }
-        return wishlistPage.map(WishlistItemResponse::from);
+        return wishlistPage.map(wishlist -> WishlistItemResponse.from(wishlist, fileStorage));
     }
 
     @Transactional

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
@@ -465,10 +465,11 @@ class PlaceServiceTest {
             Place place = createMockPlace(1L, "place/image.jpg");
             PageRequest pageable = PageRequest.of(0, 10);
             PageRequest sorted = pageable.withSort(PlaceSortType.LATEST.toSort());
-            Page<Place> placePage = new PageImpl<>(List.of(place), sorted, 1);
+            Page<Long> idPage = new PageImpl<>(List.of(1L), sorted, 1);
 
-            given(placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
-                    .willReturn(placePage);
+            given(placeRepository.findIdsByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
+                    .willReturn(idPage);
+            given(placeRepository.findAllByIdWithDetails(List.of(1L))).willReturn(List.of(place));
             given(wishlistReader.getWishedPlaceIdSet(userId, List.of(1L))).willReturn(Set.of(1L));
             given(fileStorage.generatePublicUrl("place/image.jpg"))
                     .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
@@ -482,7 +483,7 @@ class PlaceServiceTest {
             assertThat(result.getContent().get(0).wished()).isTrue();
             assertThat(result.getContent().get(0).representativeImageUrl())
                     .isEqualTo("http://localhost:9000/goyo-local/place/image.jpg");
-            verify(placeRepository).findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted);
+            verify(placeRepository).findIdsByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted);
         }
 
         @Test
@@ -491,10 +492,11 @@ class PlaceServiceTest {
             Long userId = 1L;
             Place place = createMockPlace(1L, "place/image.jpg");
             PageRequest pageable = PageRequest.of(0, 10);
-            Page<Place> placePage = new PageImpl<>(List.of(place), pageable, 1);
+            Page<Long> idPage = new PageImpl<>(List.of(1L), pageable, 1);
 
-            given(placeRepository.findAllByUserIdOrderByWishCountDesc(userId, pageable))
-                    .willReturn(placePage);
+            given(placeRepository.findIdsByUserIdOrderByWishCountDesc(userId, pageable))
+                    .willReturn(idPage);
+            given(placeRepository.findAllByIdWithDetails(List.of(1L))).willReturn(List.of(place));
             given(wishlistReader.getWishedPlaceIdSet(userId, List.of(1L))).willReturn(Set.of());
             given(fileStorage.generatePublicUrl("place/image.jpg"))
                     .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
@@ -505,7 +507,7 @@ class PlaceServiceTest {
             // then
             assertThat(result.getContent()).hasSize(1);
             assertThat(result.getContent().get(0).wished()).isFalse();
-            verify(placeRepository).findAllByUserIdOrderByWishCountDesc(userId, pageable);
+            verify(placeRepository).findIdsByUserIdOrderByWishCountDesc(userId, pageable);
         }
 
         @Test
@@ -514,10 +516,11 @@ class PlaceServiceTest {
             Long userId = 1L;
             PageRequest pageable = PageRequest.of(0, 10);
             PageRequest sorted = pageable.withSort(PlaceSortType.LATEST.toSort());
-            Page<Place> emptyPage = new PageImpl<>(List.of(), sorted, 0);
+            Page<Long> emptyPage = new PageImpl<>(List.of(), sorted, 0);
 
-            given(placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
+            given(placeRepository.findIdsByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
                     .willReturn(emptyPage);
+            given(placeRepository.findAllByIdWithDetails(List.of())).willReturn(List.of());
             given(wishlistReader.getWishedPlaceIdSet(userId, List.of())).willReturn(Set.of());
 
             // when

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
@@ -19,6 +19,7 @@ import io.dnd.goyo.common.util.GeometryUtils;
 import io.dnd.goyo.domain.place.dto.request.PlaceImageRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceRegisterRequest;
 import io.dnd.goyo.domain.place.dto.request.PlaceUpdateRequest;
+import io.dnd.goyo.domain.place.dto.response.MyPlaceResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceDetailResponse;
 import io.dnd.goyo.domain.place.dto.response.PlaceMapItemResponse;
 import io.dnd.goyo.domain.place.entity.Place;
@@ -29,6 +30,8 @@ import io.dnd.goyo.domain.place.enums.CrowdStatus;
 import io.dnd.goyo.domain.place.enums.Mood;
 import io.dnd.goyo.domain.place.enums.OutletScore;
 import io.dnd.goyo.domain.place.enums.PlaceCategory;
+import io.dnd.goyo.domain.place.enums.PlaceSortType;
+import io.dnd.goyo.domain.place.enums.PlaceStatus;
 import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.dnd.goyo.domain.place.repository.PlaceRepository;
 import io.dnd.goyo.domain.placetag.service.PlaceTagService;
@@ -53,6 +56,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class PlaceServiceTest {
@@ -442,6 +448,96 @@ class PlaceServiceTest {
             given(place.getRegionCode()).willReturn(new RegionCode(1168010100L));
             given(place.getLocation()).willReturn(location);
             given(place.getImages()).willReturn(new ArrayList<>(List.of(image)));
+            given(place.getPlaceDetail()).willReturn(placeDetail);
+
+            return place;
+        }
+    }
+
+    @Nested
+    @DisplayName("내 등록 공간 조회")
+    class GetMyPlaces {
+
+        @Test
+        void 최신순_정렬로_내_공간_목록_조회_성공() {
+            // given
+            Long userId = 1L;
+            Place place = createMockPlace(1L, "place/image.jpg");
+            PageRequest pageable = PageRequest.of(0, 10);
+            PageRequest sorted = pageable.withSort(PlaceSortType.LATEST.toSort());
+            Page<Place> placePage = new PageImpl<>(List.of(place), sorted, 1);
+
+            given(placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
+                    .willReturn(placePage);
+            given(wishlistReader.getWishedPlaceIdSet(userId, List.of(1L))).willReturn(Set.of(1L));
+            given(fileStorage.generatePublicUrl("place/image.jpg"))
+                    .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
+
+            // when
+            Page<MyPlaceResponse> result = placeService.getMyPlaces(userId, pageable, PlaceSortType.LATEST);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).placeId()).isEqualTo(1L);
+            assertThat(result.getContent().get(0).wished()).isTrue();
+            assertThat(result.getContent().get(0).representativeImageUrl())
+                    .isEqualTo("http://localhost:9000/goyo-local/place/image.jpg");
+            verify(placeRepository).findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted);
+        }
+
+        @Test
+        void 인기순_정렬로_내_공간_목록_조회_성공() {
+            // given
+            Long userId = 1L;
+            Place place = createMockPlace(1L, "place/image.jpg");
+            PageRequest pageable = PageRequest.of(0, 10);
+            Page<Place> placePage = new PageImpl<>(List.of(place), pageable, 1);
+
+            given(placeRepository.findAllByUserIdOrderByWishCountDesc(userId, pageable))
+                    .willReturn(placePage);
+            given(wishlistReader.getWishedPlaceIdSet(userId, List.of(1L))).willReturn(Set.of());
+            given(fileStorage.generatePublicUrl("place/image.jpg"))
+                    .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
+
+            // when
+            Page<MyPlaceResponse> result = placeService.getMyPlaces(userId, pageable, PlaceSortType.POPULAR);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).wished()).isFalse();
+            verify(placeRepository).findAllByUserIdOrderByWishCountDesc(userId, pageable);
+        }
+
+        @Test
+        void 공간_목록이_비어있으면_빈_페이지_반환() {
+            // given
+            Long userId = 1L;
+            PageRequest pageable = PageRequest.of(0, 10);
+            PageRequest sorted = pageable.withSort(PlaceSortType.LATEST.toSort());
+            Page<Place> emptyPage = new PageImpl<>(List.of(), sorted, 0);
+
+            given(placeRepository.findAllByUserIdAndStatus(userId, PlaceStatus.ACTIVE, sorted))
+                    .willReturn(emptyPage);
+            given(wishlistReader.getWishedPlaceIdSet(userId, List.of())).willReturn(Set.of());
+
+            // when
+            Page<MyPlaceResponse> result = placeService.getMyPlaces(userId, pageable, PlaceSortType.LATEST);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+        }
+
+        private Place createMockPlace(Long id, String imageKey) {
+            PlaceDetail placeDetail = mock(PlaceDetail.class);
+            given(placeDetail.getMood()).willReturn(Mood.CALM);
+            given(placeDetail.getSpaceSize()).willReturn(SpaceSize.MEDIUM);
+            given(placeDetail.getWishCount()).willReturn(5);
+
+            Place place = mock(Place.class);
+            given(place.getId()).willReturn(id);
+            given(place.getName()).willReturn("테스트 카페 " + id);
+            given(place.getRepresentativeImageKey()).willReturn(imageKey);
             given(place.getPlaceDetail()).willReturn(placeDetail);
 
             return place;

--- a/src/test/java/io/dnd/goyo/domain/wishlist/controller/WishlistControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/wishlist/controller/WishlistControllerTest.java
@@ -13,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dnd.goyo.domain.place.enums.Mood;
+import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.dnd.goyo.domain.wishlist.dto.request.WishlistAddRequest;
 import io.dnd.goyo.domain.wishlist.dto.response.WishCountResponse;
 import io.dnd.goyo.domain.wishlist.dto.response.WishlistItemResponse;
@@ -86,8 +88,8 @@ class WishlistControllerTest {
     @Test
     void 내_찜_목록_조회_성공_시_200_반환() throws Exception {
         WishlistItemResponse response = new WishlistItemResponse(
-                1L, 10L, "테스트 카페", null, "서울시 강남구",
-                11110L, "image.jpg", 37.5, 127.0, null, null, null
+                1L, 10L, "테스트 카페", "http://localhost:9000/goyo-local/place/image.jpg",
+                Mood.CALM, SpaceSize.MEDIUM, 5, true, null
         );
         Page<WishlistItemResponse> page = new PageImpl<>(List.of(response));
 

--- a/src/test/java/io/dnd/goyo/domain/wishlist/service/WishlistServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/wishlist/service/WishlistServiceTest.java
@@ -9,8 +9,11 @@ import static org.mockito.Mockito.verify;
 
 import io.dnd.goyo.common.exception.BusinessException;
 import io.dnd.goyo.common.exception.ErrorCode;
+import io.dnd.goyo.common.storage.FileStorage;
 import io.dnd.goyo.domain.place.entity.Place;
 import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.enums.Mood;
+import io.dnd.goyo.domain.place.enums.SpaceSize;
 import io.dnd.goyo.domain.place.repository.PlaceDetailRepository;
 import io.dnd.goyo.domain.place.service.PlaceReader;
 import io.dnd.goyo.domain.user.entity.User;
@@ -54,6 +57,9 @@ class WishlistServiceTest {
 
     @Mock
     private WishlistReader wishlistReader;
+
+    @Mock
+    private FileStorage fileStorage;
 
     @Nested
     @DisplayName("찜 추가")
@@ -130,17 +136,18 @@ class WishlistServiceTest {
             Wishlist wishlist = mock(Wishlist.class);
             Place place = mock(Place.class);
             PlaceDetail placeDetail = mock(PlaceDetail.class);
-            org.locationtech.jts.geom.Point location = mock(org.locationtech.jts.geom.Point.class);
 
             given(wishlist.getId()).willReturn(1L);
             given(wishlist.getPlace()).willReturn(place);
             given(place.getId()).willReturn(10L);
             given(place.getName()).willReturn("테스트 카페");
+            given(place.getRepresentativeImageKey()).willReturn("place/image.jpg");
             given(place.getPlaceDetail()).willReturn(placeDetail);
-            given(place.getLocation()).willReturn(location);
-            given(place.getRegionCode()).willReturn(new io.dnd.goyo.domain.place.entity.RegionCode(11110L));
-            given(location.getY()).willReturn(37.5);
-            given(location.getX()).willReturn(127.0);
+            given(placeDetail.getMood()).willReturn(Mood.CALM);
+            given(placeDetail.getSpaceSize()).willReturn(SpaceSize.MEDIUM);
+            given(placeDetail.getWishCount()).willReturn(5);
+            given(fileStorage.generatePublicUrl("place/image.jpg"))
+                    .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
 
             PageRequest pageable = PageRequest.of(0, 10);
             PageRequest sorted = pageable.withSort(WishlistSortType.LATEST.toSort());
@@ -153,7 +160,9 @@ class WishlistServiceTest {
 
             // then
             assertThat(result.getContent()).hasSize(1);
-            assertThat(result.getContent().get(0).placeId()).isEqualTo(10L);
+            assertThat(result.getContent().getFirst().placeId()).isEqualTo(10L);
+            assertThat(result.getContent().getFirst().representativeImageUrl())
+                    .isEqualTo("http://localhost:9000/goyo-local/place/image.jpg");
         }
 
         @Test
@@ -181,17 +190,18 @@ class WishlistServiceTest {
             Wishlist wishlist = mock(Wishlist.class);
             Place place = mock(Place.class);
             PlaceDetail placeDetail = mock(PlaceDetail.class);
-            org.locationtech.jts.geom.Point location = mock(org.locationtech.jts.geom.Point.class);
 
             given(wishlist.getId()).willReturn(1L);
             given(wishlist.getPlace()).willReturn(place);
             given(place.getId()).willReturn(10L);
             given(place.getName()).willReturn("테스트 카페");
+            given(place.getRepresentativeImageKey()).willReturn("place/image.jpg");
             given(place.getPlaceDetail()).willReturn(placeDetail);
-            given(place.getLocation()).willReturn(location);
-            given(place.getRegionCode()).willReturn(new io.dnd.goyo.domain.place.entity.RegionCode(11110L));
-            given(location.getY()).willReturn(37.5);
-            given(location.getX()).willReturn(127.0);
+            given(placeDetail.getMood()).willReturn(Mood.CALM);
+            given(placeDetail.getSpaceSize()).willReturn(SpaceSize.MEDIUM);
+            given(placeDetail.getWishCount()).willReturn(5);
+            given(fileStorage.generatePublicUrl("place/image.jpg"))
+                    .willReturn("http://localhost:9000/goyo-local/place/image.jpg");
 
             PageRequest pageable = PageRequest.of(0, 10);
             Page<Wishlist> wishlistPage = new PageImpl<>(List.of(wishlist), pageable, 1);


### PR DESCRIPTION
## 💡 작업 내용                                                                                                                                                                                                                                                                                                                                                                                                                                                     
- [x] 내 등록 공간 목록 조회 API 구현                                                                                                                                                     
- [x] 위시 목록 조회 응답 필드 정리                                                                                                                                                                                                                       
                  
## 💡 자세한 설명

**내 등록 공간 조회**
최신순/이름순/인기순 정렬을 지원하는 내 등록 공간 목록 조회 API를 구현했습니다.

## ✅ 셀프 체크리스트

- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #55 