### PR TITLE
fix: 사용자 리뷰 통계 비로그인한 사용자도 볼 수 있도록 수정

### DIFF
--- a/src/main/java/io/dnd/goyo/config/SecurityConfig.java
+++ b/src/main/java/io/dnd/goyo/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
                             "/api/places/*/wish-count",
                             "/api/reviews/*",
                             "/api/places/*/reviews",
+                            "/api/places/*/reviews/tag-stats",
+                            "/api/places/*/reviews/rating-stats",
                             "/api/users/nickname/check"
                     ).permitAll()
                     .anyRequest().authenticated()


### PR DESCRIPTION
## 💡 작업 내용
- [x] 사용자 리뷰 통계 비로그인한 사용자도 볼 수 있도록 수정하였습니다.

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #68 
