### PR TITLE
fix: 장소 상세 조회시 tagId 추가 및 뱃지 달성 여부 조건 수정

### DIFF
--- a/src/main/java/io/dnd/goyo/domain/badge/service/BadgeService.java
+++ b/src/main/java/io/dnd/goyo/domain/badge/service/BadgeService.java
@@ -55,11 +55,12 @@ public class BadgeService {
         List<BadgeProgress> badges = BadgeCode.getByActivityType(activityType).stream()
                 .map(badgeCode -> {
                     UserBadge userBadge = achievedBadgeMap.get(badgeCode.getCode());
+                    boolean achieved = userBadge != null || currentCount >= badgeCode.getThreshold();
                     return new BadgeProgress(
                             badgeCode.getCode(),
                             badgeCode.getDisplayName(),
                             badgeCode.getThreshold(),
-                            userBadge != null,
+                            achieved,
                             userBadge != null ? userBadge.getCreatedAt() : null
                     );
                 })

--- a/src/main/java/io/dnd/goyo/domain/place/dto/response/PlaceDetailResponse.java
+++ b/src/main/java/io/dnd/goyo/domain/place/dto/response/PlaceDetailResponse.java
@@ -65,10 +65,13 @@ public record PlaceDetailResponse(
         @Schema(description = "화장실 정보", example = "내부")
         String restroomInfo,
 
+        @Schema(description = "태그 ID 목록", example = "[1, 2, 3]")
+        List<Long> tagIds,
+
         @Schema(description = "위시 여부", example = "true")
         boolean isWished
 ) {
-    public static PlaceDetailResponse from(Place place, boolean isWished, FileStorage fileStorage) {
+    public static PlaceDetailResponse from(Place place, boolean isWished, List<Long> tagIds, FileStorage fileStorage) {
         PlaceDetail detail = place.getPlaceDetail();
         Point location = place.getLocation();
         List<PlaceImageItem> images = PlaceImageItem.listOf(place.getImages(), fileStorage);
@@ -91,6 +94,7 @@ public record PlaceDetailResponse(
                 place.getCloseTime(),
                 place.getFloorInfo(),
                 place.getRestroomInfo(),
+                tagIds,
                 isWished
         );
     }

--- a/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
+++ b/src/main/java/io/dnd/goyo/domain/place/service/PlaceService.java
@@ -85,7 +85,9 @@ public class PlaceService {
             eventPublisher.publishEvent(new PlaceViewedEvent(userId, placeId));
         }
 
-        return PlaceDetailResponse.from(place, isWished, fileStorage);
+        List<Long> tagIds = placeTagService.getTagIds(placeId);
+
+        return PlaceDetailResponse.from(place, isWished, tagIds, fileStorage);
     }
 
     @Transactional

--- a/src/main/java/io/dnd/goyo/domain/placetag/service/PlaceTagService.java
+++ b/src/main/java/io/dnd/goyo/domain/placetag/service/PlaceTagService.java
@@ -40,6 +40,10 @@ public class PlaceTagService {
         registerPlaceTags(place, tagIds);
     }
 
+    public List<Long> getTagIds(Long placeId) {
+        return placeTagRepository.findTagIdsByPlaceId(placeId);
+    }
+
     private List<Tag> findAndValidateTags(List<Long> tagIds) {
         List<Tag> tags = tagRepository.findAllById(tagIds);
         if (tags.size() != tagIds.size()) {

--- a/src/test/java/io/dnd/goyo/domain/badge/service/BadgeServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/badge/service/BadgeServiceTest.java
@@ -92,6 +92,34 @@ class BadgeServiceTest {
     }
 
     @Test
+    @DisplayName("UserBadge 없어도 카운트가 임계값 이상이면 achieved true")
+    void UserBadge_없어도_카운트가_임계값_이상이면_achieved_true() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class);
+        UserStats userStats = UserStats.of(user);
+        userStats.incrementPlaceCount(); // placeCount = 1, PLACE_1 threshold = 1
+
+        given(userStatsRepository.findByUserId(userId)).willReturn(Optional.of(userStats));
+        given(userBadgeRepository.findAllByUserId(userId)).willReturn(List.of());
+
+        // when
+        BadgeProgressResponse response = badgeService.getBadgeProgress(userId);
+
+        // then
+        CategoryProgress placeCategory = response.categories().stream()
+                .filter(c -> c.activityType() == ActivityType.PLACE)
+                .findFirst().orElseThrow();
+
+        assertThat(placeCategory.currentCount()).isEqualTo(1);
+        // PLACE_1: threshold 1, currentCount 1 → UserBadge 없어도 achieved = true
+        assertThat(placeCategory.badges().get(0).achieved()).isTrue();
+        assertThat(placeCategory.badges().get(0).achievedAt()).isNull();
+        // PLACE_7: threshold 7, currentCount 1 → achieved = false
+        assertThat(placeCategory.badges().get(1).achieved()).isFalse();
+    }
+
+    @Test
     @DisplayName("UserStats가 없으면 예외 발생")
     void UserStats가_없으면_예외_발생() {
         // given

--- a/src/test/java/io/dnd/goyo/domain/place/controller/PlaceControllerTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/controller/PlaceControllerTest.java
@@ -273,6 +273,7 @@ class PlaceControllerTest {
                     LocalTime.of(22, 0),
                     1,
                     "내부/남녀공용",
+                    List.of(1L, 2L),
                     isWished
             );
         }

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceIntegrationTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceIntegrationTest.java
@@ -1,0 +1,147 @@
+package io.dnd.goyo.domain.place.service;
+
+import io.dnd.goyo.common.storage.FileStorage;
+import io.dnd.goyo.domain.place.entity.Place;
+import io.dnd.goyo.domain.place.entity.PlaceDetail;
+import io.dnd.goyo.domain.place.entity.PlaceImage;
+import io.dnd.goyo.domain.place.enums.PlaceCategory;
+import io.dnd.goyo.domain.place.enums.PlaceStatus;
+import io.dnd.goyo.domain.place.repository.PlaceDetailRepository;
+import io.dnd.goyo.domain.place.repository.PlaceRepository;
+import io.dnd.goyo.domain.user.entity.User;
+import io.dnd.goyo.domain.user.entity.UserStats;
+import io.dnd.goyo.domain.user.enums.Gender;
+import io.dnd.goyo.domain.user.enums.Provider;
+import io.dnd.goyo.domain.user.enums.UserRole;
+import io.dnd.goyo.domain.user.repository.UserRepository;
+import io.dnd.goyo.domain.user.repository.UserStatsRepository;
+import io.dnd.goyo.domain.wishlist.entity.Wishlist;
+import io.dnd.goyo.domain.wishlist.repository.WishlistRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@Transactional
+class PlaceServiceIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:16-3.4-alpine")
+                    .asCompatibleSubstituteFor("postgres")
+    );
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private PlaceService placeService;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private PlaceDetailRepository placeDetailRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserStatsRepository userStatsRepository;
+
+    @Autowired
+    private WishlistRepository wishlistRepository;
+
+    @Autowired
+    private GeometryFactory geometryFactory;
+
+    @MockitoBean
+    private FileStorage fileStorage;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        given(fileStorage.generatePublicUrl(anyString())).willAnswer(inv -> inv.getArgument(0));
+
+        user = userRepository.save(User.builder()
+                .name("테스트유저")
+                .nickname("테스트닉네임")
+                .gender(Gender.MALE)
+                .age(30)
+                .provider(Provider.KAKAO)
+                .providerId("test_001")
+                .role(UserRole.USER)
+                .build());
+
+        userStatsRepository.save(UserStats.of(user));
+    }
+
+    @Test
+    @DisplayName("공간 삭제 시 찜이 있어도 status가 DELETED로 변경되어야 한다")
+    void deletePlace_withWishlist_statusShouldBeDeleted() {
+        // given
+        Place place = savePlace("테스트 카페");
+        wishlistRepository.save(Wishlist.of(user, place));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        placeService.deletePlace(user.getId(), place.getId());
+
+        // then - 영속성 컨텍스트가 clear된 상태이므로 DB에서 직접 조회
+        PlaceStatus status = entityManager
+                .createQuery("SELECT p.status FROM Place p WHERE p.id = :id", PlaceStatus.class)
+                .setParameter("id", place.getId())
+                .getSingleResult();
+
+        assertThat(status).isEqualTo(PlaceStatus.DELETED);
+    }
+
+    private Place savePlace(String name) {
+        Place place = Place.builder()
+                .name(name)
+                .category(PlaceCategory.CAFE)
+                .location(geometryFactory.createPoint(new Coordinate(126.9769, 37.5759)))
+                .regionCode(1101005200L)
+                .addressDetail("테스트 주소")
+                .user(user)
+                .openTime(LocalTime.of(9, 0))
+                .closeTime(LocalTime.of(22, 0))
+                .build();
+        place.addImages(List.of(PlaceImage.of("places/test.jpg", true, 0)));
+        placeRepository.saveAndFlush(place);
+        placeDetailRepository.saveAndFlush(PlaceDetail.of(place, 50, 50, 50, 50));
+        return place;
+    }
+}

--- a/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
+++ b/src/test/java/io/dnd/goyo/domain/place/service/PlaceServiceTest.java
@@ -214,6 +214,28 @@ class PlaceServiceTest {
             verify(fileStorage).generatePublicUrl("place/image1.jpg");
         }
 
+        @Test
+        void 공간_상세_조회_시_태그ID_목록_포함() {
+            // given
+            Long userId = 1L;
+            Long placeId = 1L;
+            Place place = createMockPlace(placeId);
+            List<Long> tagIds = List.of(1L, 2L, 3L);
+
+            given(placeRepository.findByIdWithDetails(placeId)).willReturn(Optional.of(place));
+            given(wishlistReader.isWished(userId, placeId)).willReturn(false);
+            given(placeTagService.getTagIds(placeId)).willReturn(tagIds);
+            given(fileStorage.generatePublicUrl("place/image1.jpg"))
+                    .willReturn("http://localhost:9000/goyo-local/place/image1.jpg");
+
+            // when
+            PlaceDetailResponse response = placeService.getPlaceDetail(userId, placeId);
+
+            // then
+            assertThat(response.tagIds()).containsExactly(1L, 2L, 3L);
+            verify(placeTagService).getTagIds(placeId);
+        }
+
         private Place createMockPlace(Long placeId) {
             PlaceDetail placeDetail = mock(PlaceDetail.class);
             given(placeDetail.getAverageRating()).willReturn(4.5);


### PR DESCRIPTION
## 💡 작업 내용
- [x] 뱃지 초기 데이터가 없어도 동작할 수 있도록 방어로직 추가
- [x] 장소 상세 조회시 tagId 추가

## ✅ 셀프 체크리스트
- [x]  머지할 브랜치 확인했나요?
- [x]  이슈는 close 했나요?
- [x]  Reviewers, Labels, Projects를 등록했나요?
- [x]  기능이 잘 동작하나요?
- [x]  불필요한 코드는 제거했나요?

closes #78 
